### PR TITLE
Calf Trigger prototype

### DIFF
--- a/doc/manuals/Trigger.html
+++ b/doc/manuals/Trigger.html
@@ -1,0 +1,41 @@
+<html>
+    <head>
+        <link type="text/css" rel="stylesheet" href="scripts/thickbox.css" />
+        <link type="text/css" rel="stylesheet" href="scripts/style.css" />
+        <script language="javascript" type="text/javascript" src="scripts/jquery.js"></script>
+        <script language="javascript" type="text/javascript" src="scripts/thickbox.js"></script>
+        <script language="javascript" type="text/javascript" src="scripts/manual.js"></script>
+    </head>
+    <body>
+        <div class="wrapper">
+            <h1>Trigger</h1>
+            <a href="images/Calf - Trigger.png" title="Calf - Impulses" class="thickbox"><img class="thumbnail" src="images/Calf - Trigger.png" /></a>
+            <h2>Functionality</h2>
+            <p>
+			This plugin implements simple triggering module.
+			If your kick/toms/snare or other stuff was badly recorded (our regrets...) you can fix it by using this plugin.
+			Just load good sample, configure this plugin and enjoy.
+			Output signal may have some delay.
+            </p>
+            <h2>Controls</h2>
+            <ul>
+		<li><strong>Input</strong>: Input signal level</li>
+		<li><strong>Bypass</strong>: Bypass signal</li>
+		<li><strong>Look-ahead</strong>: Signal level detection time</li>
+		<li><strong>Open threshold</strong>: The threshold of input signal that makes trigger to begin to turn on</li>
+		<li><strong>Close threshold</strong>: The threshold of input signal that makes trigger to begn to turn off</li>
+		<li><strong>Release</strong>: The time trigger keeps turned on after input signal reached close threhold</li>
+		<li><strong>Dynamics mode</strong>: The algorithms of level and attack detection</li>
+		<li><strong>Dynamics</strong>: The dynamics of triggered signal</li>
+		<li><strong>Dry</strong>: Amount of dry (unprocessed) signal</li>
+		<li><strong>Wet</strong>: Amount of wet (processed) signal</li>
+		<li><strong>File</strong>: Sample file to play when trigger turns on</li>
+		<li><strong>Tracks (L/R)</strong>: Number of track of sample file to play in left and right channels</li>
+		<li><strong>Head cutoff</strong>: Number of milliseconds to cut from heading of sample (for example, when there is silence at the head)</li>
+		<li><strong>Tail</strong>: The overall length of sample to use</li>
+		<li><strong>Playbacks</strong>: Maximum number of sample playbacks at the same time.</li>
+		<li><strong>Volume</strong>: Output volume</li>
+            </ul>
+        </div>
+    </body>
+</html>

--- a/doc/manuals/scripts/manual.js
+++ b/doc/manuals/scripts/manual.js
@@ -96,6 +96,7 @@ $(document).ready(function () {
                 ["(X-Over 2 Band)", "X-Over 2 Band.html", "images/Calf - X-Over 2 Band.jpg"],
                 ["(X-Over 3 Band)", "X-Over 3 Band.html", "images/Calf - X-Over 3 Band.jpg"],
                 ["(X-Over 4 Band)", "X-Over 4 Band.html", "images/Calf - X-Over 4 Band.jpg"],
+                ["Trigger", "Trigger.html", "images/Calf - Trigger.png"]
             ],
             "icons/tools.png"
         ]

--- a/gui/gui-trigger.xml
+++ b/gui/gui-trigger.xml
@@ -1,0 +1,131 @@
+<hbox spacing="7">
+    <frame label="Input" expand="1" fill="1">
+        <vbox spacing="6">
+			<label param="in_gain" />
+            <knob param="in_gain" size="5" />
+            <value param="in_gain" />
+            <label />
+			<label param="bypass" />
+			<toggle param="bypass" />
+		</vbox>
+    </frame>
+    
+    <vbox expand-x="2">
+    	<frame label="Trigger">
+    		<vbox spacing="2">
+	   			<hbox>
+	    			<table rows="2" cols="5" >
+		    			<label attach-x="0" attach-y="0" fill-x="0" expand-x="0" fill-y="0" expand-y="0" text="L" />
+			            <vumeter param="mtr_input_l" mode="0" position="2" hold="1.5" falloff="2.5" attach-x="1" attach-y="0" fill-x="1" />
+			            <led param="flash_l" attach-x="2" attach-y="0" fill-x="0" expand-x="0" fill-y="0" expand-y="0" />
+			            
+			  			<label attach-x="0" attach-y="1" fill-x="0" expand-x="0" fill-y="0" expand-y="0" text="R" />
+						<vumeter param="mtr_input_r" mode="0" position="2" hold="1.5" falloff="2.5" attach-x="1" attach-y="1" fill-x="1" />
+						<led param="flash_r" attach-x="2" attach-y="1" fill-x="0" expand-x="0" fill-y="0" expand-y="0" />
+					</table>
+				</hbox>
+				
+				<table rows="2" cols="4">	
+					<vbox attach-x="0" attach-y="0">
+						<label param="lookup" />
+						<knob param="lookup" size="2" />
+						<value param="lookup" />
+					</vbox>
+					
+					<vbox attach-x="1" attach-y="0">
+						<label param="open_threshold" />
+						<knob param="open_threshold" size="2" />
+						<value param="open_threshold" />
+					</vbox>
+					
+					<vbox attach-x="2" attach-y="0">
+						<label param="close_threshold" />
+						<knob param="close_threshold" size="2" />
+						<value param="close_threshold" />
+					</vbox>
+					
+					<vbox attach-x="3" attach-y="0">
+						<label param="release" />
+						<knob param="release" size="2" />
+						<value param="release" />
+					</vbox>
+					
+					<vbox attach-x="0" attach-y="1">
+						<label param="dyn_mode" />
+						<combo param="dyn_function" />
+						<combo param="dyn_mode" />
+					</vbox>
+					
+					<vbox attach-x="1" attach-y="1">
+						<label param="dyn_amount" />
+						<knob param="dyn_amount" size="2" />
+						<value param="dyn_amount" />
+					</vbox>
+					
+					<vbox attach-x="2" attach-y="1">
+						<label param="dry" />
+						<knob param="dry" size="2" />
+						<value param="dry" />
+					</vbox>
+					
+					<vbox attach-x="3" attach-y="1">
+						<label param="wet" />
+						<knob param="wet" size="2" />
+						<value param="wet" />
+					</vbox>
+	    		</table>
+	    	</vbox>
+    	</frame>
+    	<frame label="Sample" >
+    		<vbox spacing="2">
+	    		<hbox>
+	    			<label text="File" />
+		        	<filechooser key="file" title="Sample file" width_chars="30"/>
+	    		</hbox>
+	    		<table rows="2" cols="3">
+	    			<label attach-x="0" attach-y="0" text="Tracks (L/R)" />
+	    			<hbox attach-x="1" attach-y="0">
+						<combo param="sample_track_l" />
+					</hbox>
+					<hbox attach-x="2" attach-y="0">
+						<combo param="sample_track_r" />
+					</hbox>
+					
+					<vbox attach-x="0" attach-y="1">
+						<label text="Head cutoff" />
+						<knob param="head_cutoff" size="2" />
+						<value param="head_cutoff" />
+					</vbox>
+					
+					<vbox attach-x="1" attach-y="1">
+						<label text="Tail cutoff" />
+						<knob param="tail_cutoff" size="2" />
+						<value param="tail_cutoff" />
+					</vbox>
+					
+					<vbox attach-x="2" attach-y="1">
+						<label text="Playbacks" />
+						<knob param="playbacks" size="2" />
+						<value param="playbacks" />
+					</vbox>
+	    		</table>
+	    	</vbox>
+    	</frame>
+    </vbox>
+    
+    <frame label="Output" expand="1" fill="1">
+        <vbox spacing="6">
+			<label param="out_gain" />
+            <knob param="out_gain" size="5" />
+            <value param="out_gain" />
+            
+            <table rows="2" cols="1"> 
+	            <label attach-x="0" attach-y="0" fill-x="0" expand-x="0" fill-y="0" expand-y="0" text="L" />
+	            <vumeter param="mtr_output_l" mode="0" position="2" hold="1.5" falloff="2.5" attach-x="0" attach-y="0" fill-x="1" />
+	  			<label attach-x="0" attach-y="1" fill-x="0" expand-x="0" fill-y="0" expand-y="0" text="r" />
+				<vumeter param="mtr_output_r" mode="0" position="2" hold="1.5" falloff="2.5" attach-x="0" attach-y="1" fill-x="1" />
+			</table>
+		</vbox>
+    </frame>
+</hbox>
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,7 +37,7 @@ calfmakerdf_LDADD = calf.la
 calfbenchmark_SOURCES = benchmark.cpp
 calfbenchmark_LDADD = calf.la
 
-calf_la_SOURCES = audio_fx.cpp analyzer.cpp metadata.cpp modules_tools.cpp modules_delay.cpp modules_comp.cpp modules_limit.cpp modules_dist.cpp modules_filter.cpp modules_mod.cpp modules_pitch.cpp fluidsynth.cpp giface.cpp monosynth.cpp organ.cpp osctl.cpp plugin.cpp preset.cpp synth.cpp utils.cpp wavetable.cpp modmatrix.cpp
+calf_la_SOURCES = audio_fx.cpp analyzer.cpp metadata.cpp modules_tools.cpp modules_delay.cpp modules_comp.cpp modules_limit.cpp modules_dist.cpp modules_filter.cpp modules_mod.cpp modules_pitch.cpp fluidsynth.cpp trigger.cpp giface.cpp monosynth.cpp organ.cpp osctl.cpp plugin.cpp preset.cpp synth.cpp utils.cpp wavetable.cpp modmatrix.cpp
 calf_la_LIBADD = $(FLUIDSYNTH_DEPS_LIBS) $(GLIB_DEPS_LIBS) 
 if USE_DEBUG
 calf_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat -disable-static

--- a/src/calf/metadata.h
+++ b/src/calf/metadata.h
@@ -939,6 +939,62 @@ struct pitch_metadata: public plugin_metadata<pitch_metadata>
     PLUGIN_NAME_ID_LABEL("pitch", "pitch", "Pitch Tools")
 };
 
+// Trigger metadata
+struct trigger_metadata: public plugin_metadata<trigger_metadata>
+{
+    // Parameters
+    enum
+    {
+        mtr_input_l,
+        mtr_input_r,
+        mtr_output_l,
+        mtr_output_r,
+        flash_l,
+        flash_r,
+
+        par_bypass,
+        par_in_gain,
+        par_lookup,
+        par_open_threshold,
+        par_close_threshold,
+        par_release,
+        par_sample_track_l,
+        par_sample_track_r,
+        par_sample_head,
+        par_sample_tail,
+        par_sample_playbacks,
+        par_dyn_mode,
+        par_dyn_function,
+        par_dyn_amount,
+        par_dry,
+        par_wet,
+        par_out_gain,
+
+        param_count
+    };
+
+    // Modes of dynamic
+    enum
+    {
+        dyn_mode1,
+        dyn_mode2
+    };
+
+    // Inputs, outputs, etc...
+    enum
+    {
+        in_count = 2,
+        out_count = 2,
+        ins_optional = 0,
+        outs_optional = 0,
+        rt_capable = true,
+        support_midi = false,
+        require_midi = false
+    };
+
+    PLUGIN_NAME_ID_LABEL("trigger", "trigger", "Trigger")
+};
+
 };
 
 #endif

--- a/src/calf/modulelist.h
+++ b/src/calf/modulelist.h
@@ -82,6 +82,7 @@
 #ifdef ENABLE_EXPERIMENTAL
     // Pitch tools
     PER_MODULE_ITEM(pitch,               false, "pitch")
+    PER_MODULE_ITEM(trigger,             false, "trigger")
 #endif
 
 #undef PER_MODULE_ITEM

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1963,6 +1963,66 @@ CALF_PLUGIN_INFO(pitch) = { 0x85AA, "Pitch", "Calf Pitch Tols", "Calf Studio Gea
 
 ////////////////////////////////////////////////////////////////////////////
 
+#if ENABLE_EXPERIMENTAL
+CALF_PORT_NAMES(trigger) = {"In L", "In R", "Out L", "Out R"};
+
+const char *trigger_dynamics_mode[] = {
+    "Level",
+    "Peak"
+};
+
+const char *trigger_dynamics_func[] = {
+    "Linear",
+    "Root",
+    "Quad"
+};
+
+const char *trigger_file_track[] = {
+    "Track 1",
+    "Track 2",
+    "Track 3",
+    "Track 4",
+    "Track 5",
+    "Track 6",
+    "Track 7",
+    "Track 8"
+};
+
+CALF_PORT_PROPS(trigger) = {
+    // default, min, max, step, flags, choices, short_name, long name
+    { 0,           0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "mtr_input_l", "Input level L" },
+    { 0,           0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "mtr_input_r", "Input level R" },
+    { 0,           0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "mtr_output_l", "Output level L" },
+    { 0,           0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "mtr_output_r", "Output level R" },
+    { 0,           0,           1,     0,  PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "flash_l", "Fired L" },
+    { 0,           0,           1,     0,  PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "flash_r", "Fired R" },
+
+    // params
+    { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "bypass", "Bypass" },
+    { 1,           0,           4,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_NOBOUNDS , NULL, "in_gain", "Input" },
+    { 5,           0.1,         20,    0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_MSEC | PF_PROP_GRAPH, NULL, "lookup", "Look-ahead" },
+    { 0.7,         0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_NOBOUNDS, NULL, "open_threshold", "Open threshold" },
+    { 0.6,         0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_NOBOUNDS, NULL, "close_threshold", "Close threshold" },
+    { 1,           0.1,         50,    0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC | PF_PROP_GRAPH, NULL, "release", "Release" },
+    { 0,           0,           7,     1,  PF_ENUM | PF_SCALE_LINEAR | PF_CTL_COMBO, trigger_file_track, "sample_track_l", "File track L" },
+    { 1,           0,           7,     1,  PF_ENUM | PF_SCALE_LINEAR | PF_CTL_COMBO, trigger_file_track, "sample_track_r", "File track R" },
+    { 0,           0,           100,   0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_MSEC | PF_PROP_GRAPH, NULL, "head_cutoff", "Sample head cutoff" },
+    { 1,           0,           1,     0,  PF_FLOAT | PF_SCALE_PERC | PF_CTL_KNOB, NULL, "tail_cutoff", "Sample tail" },
+    { 8,           1,           16,    0,  PF_INT | PF_SCALE_LINEAR | PF_CTL_KNOB, NULL, "playbacks", "Max sample playbacks" },
+    { 0,           0,           1,     1,  PF_ENUM | PF_SCALE_LINEAR | PF_CTL_COMBO, trigger_dynamics_mode, "dyn_mode", "Dynamics mode" },
+    { 0,           0,           2,     1,  PF_ENUM | PF_SCALE_LINEAR | PF_CTL_COMBO, trigger_dynamics_func, "dyn_function", "Dynamics function" },
+    { 0.5,         0,           1,     0,  PF_FLOAT | PF_SCALE_PERC | PF_CTL_KNOB, NULL, "dyn_amount", "Dynamics amount" },
+    { 0,           0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_NOBOUNDS, NULL, "dry", "Dry signal" },
+    { 1,           0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_NOBOUNDS, NULL, "wet", "Wet signal" },
+    { 1,           0,           10,    0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_NOBOUNDS , NULL, "out_gain", "Output" },
+    {}
+};
+
+CALF_PLUGIN_INFO(trigger) = { 0x8487, "Trigger", "Calf Trigger", "Vladimir Sadovnikov", calf_plugins::calf_copyright_info, "TriggerPlugin" };
+#endif /* ENABLE_EXPERIMENTAL */
+
+////////////////////////////////////////////////////////////////////////////
+
 calf_plugins::plugin_registry::plugin_registry()
 {
     #define PER_MODULE_ITEM(name, isSynth, jackname) plugins.push_back((new name##_metadata));

--- a/src/trigger.cpp
+++ b/src/trigger.cpp
@@ -1,0 +1,487 @@
+/* Calf DSP Library
+ * Trigger implementation
+ *
+ * Copyright (C) 2013 Vladimir Sadovnikov
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, 
+ * Boston, MA  02110-1301  USA
+ */
+#include <calf/giface.h>
+#include <calf/modules_dev.h>
+#include <calf/buffer.h>
+
+#include <string.h>
+#include <math.h>
+#include <sndfile.h>
+
+#if ENABLE_EXPERIMENTAL
+
+#define SET_IF_CONNECTED(name, value) if (params[trigger_audio_module::name] != NULL) *params[trigger_audio_module::name] = value;
+
+using namespace dsp;
+using namespace calf_plugins;
+using namespace std;
+
+//-----------------------------------------------------------------------------
+// Level detectors
+template <class F>
+    void level_detector(const mono_trigger_t *trg, float &level, float &angle)
+    {
+        size_t lkp_limit    = trg->lkp_size - 1;
+        float dt            = 1.0 / trg->lkp_samples;
+        float pr_sample     = 0.0;
+        float pr_f          = 0.0;
+        float t             = 0.0;
+
+        float v_level       = 0.0;
+        float v_angle       = 0.0;
+
+        size_t l = (trg->lkp_size + trg->lkp_ptr - trg->lkp_samples) & lkp_limit; // add lkp_size for unsigned math
+        while  (l != trg->lkp_ptr)
+        {
+            float sample    = trg->lkp_buffer[l];
+            float f         = F::f(t);
+
+            v_level        += (f - pr_f) * sample;
+            v_angle        += f * (sample - pr_sample);
+
+            l               = (l + 1) & lkp_limit;
+            t              += dt;
+            pr_sample       = sample;
+            pr_f            = f;
+        }
+
+        level       = v_level;
+        angle       = v_angle;
+    }
+
+typedef struct linear_function_t
+{
+    static float f(float t)
+    {
+        return t;
+    }
+} linear_function_t;
+
+typedef struct sqrt_function_t
+{
+    static float f(float t)
+    {
+        return sqrtf(1.0 - (1.0 - t) * (1.0 - t));
+    }
+} sqrt_function_t;
+
+typedef struct quad_function_t
+{
+    static float f(float t)
+    {
+        return (1.0 - sqrtf(1.0 - t*t));
+    }
+} quad_function_t;
+
+void linear_detector(const mono_trigger_t *trg, float &level, float &attack)
+{
+    level_detector<linear_function_t>(trg, level, attack);
+}
+
+void sqrt_detector(const mono_trigger_t *trg, float &level, float &attack)
+{
+    level_detector<sqrt_function_t>(trg, level, attack);
+}
+
+void quad_detector(const mono_trigger_t *trg, float &level, float &attack)
+{
+    level_detector<quad_function_t>(trg, level, attack);
+}
+
+//-----------------------------------------------------------------------------
+void trigger_sample_t::free()
+{
+    srate       = 0;
+    channels    = 0;
+    samples     = 0;
+    filename    = "";
+
+    if (frames != NULL)
+    {
+        delete[] frames;
+        frames = NULL;
+    }
+}
+
+bool trigger_sample_t::load(const char *file)
+{
+    SNDFILE *sf_obj;
+    SF_INFO sf_info;
+
+    free();
+
+    printf("loading file: %s\n", file);
+
+    if ((sf_obj = sf_open(file, SFM_READ, &sf_info)) == NULL)
+        return false;
+
+    printf("file parameters: frames=%d, channels=%d, sample_rate=%d\n",
+            (int)sf_info.frames, (int)sf_info.channels, (int)sf_info.samplerate);
+
+    float *data = new float[sf_info.frames * sf_info.channels];
+
+    if (sf_readf_float(sf_obj, data, sf_info.frames) < sf_info.frames)
+    {
+        delete [] data;
+        sf_close(sf_obj);
+        return false;
+    }
+
+    sf_close(sf_obj);
+
+    srate           = sf_info.samplerate;
+    channels        = sf_info.channels;
+    samples         = sf_info.frames;
+    frames          = data;
+    filename        = file;
+
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+mono_trigger_t::mono_trigger_t()
+{
+    playbacks       = 0;
+    state           = TRG_STATE_CLOSED;
+    lkp_buffer      = NULL;
+    lkp_ptr         = 0;
+    lkp_size        = 0;
+    lkp_samples     = 0;
+    release         = 0;
+
+    rel_samples     = 0;
+    max_playbacks   = 0;
+    track           = -1;
+    min_offset      = 0;
+    max_offset      = 0;
+    mode            = 0;
+    open_thresh     = 0;
+    close_thresh    = 0;
+    dynamics        = 0;
+    dry             = 0;
+    wet             = 0;
+    in_gain         = 0;
+    out_gain        = 0;
+
+    mtr_in          = 0;
+    mtr_out         = 0;
+    fired           = false;
+
+    detector        = linear_detector;
+}
+
+mono_trigger_t::~mono_trigger_t()
+{
+    free();
+}
+
+void mono_trigger_t::free()
+{
+    if (lkp_buffer != NULL)
+    {
+        delete [] lkp_buffer;
+        lkp_buffer      = NULL;
+        lkp_size        = 0;
+        lkp_ptr         = 0;
+    }
+}
+
+void mono_trigger_t::change_sample_rate(uint32_t srate)
+{
+    free();
+
+    size_t max_buf_size = round(TRIGGER_MAX_LOOKUP_MS * srate * 0.001);
+    size_t buf_size = 1;
+    while (buf_size < max_buf_size)
+        buf_size <<= 1;
+
+    lkp_buffer      = new float[buf_size];
+    lkp_size        = buf_size;
+    lkp_ptr         = 0;
+}
+
+void mono_trigger_t::process(const float *in, float *out, const trigger_sample_t *t_sample, size_t count)
+{
+    size_t  lkp_limit   = lkp_size - 1;
+
+    mtr_in              = 0.0;
+    mtr_out             = 0.0;
+    fired               = false;
+
+    for (size_t i = 0; i < count; i++)
+    {
+        // Get sample
+        float sample        = in[i] * in_gain;
+        if (mtr_in < sample)
+            mtr_in = sample;
+
+        // Store sample to lookup buffer
+        lkp_buffer[lkp_ptr] = (sample < 0) ? -sample : sample;
+        lkp_ptr             = (lkp_ptr + 1) & lkp_limit;
+
+        // Perform lookup
+        float level = 0, angle = 0;
+        detector(this, level, angle);
+
+        // Check trigger state
+        if (state == TRG_STATE_CLOSED) // Trigger is closed
+        {
+            if ((level >= open_thresh) && (angle > 0)) // Signal is growing, open trigger
+            {
+                // Mark trigger open
+                state       = TRG_STATE_MEASURE;
+                fired       = true;
+                release     = rel_samples;
+            }
+        }
+        else if (state == TRG_STATE_MEASURE)
+        {
+            fired       = true;
+
+            if ((level >= open_thresh) && (angle <= 0)) // Signal is in peak
+            {
+                state = TRG_STATE_OPEN;
+
+                // Append Playback
+                if (playbacks >= max_playbacks)
+                {
+                    // Cleanup oldest playbacks
+                    size_t remove = playbacks - max_playbacks + 1;
+                    for (size_t r = remove; r < playbacks; r++)
+                        playback[r - remove] = playback[r];
+                    playbacks = max_playbacks;
+                }
+                else
+                    playbacks++;
+
+                // Initialize new playback
+                trigger_playback_t *pb = &playback[playbacks - 1];
+                pb->start(
+                    min_offset, max_offset,
+                    (mode == 0) ?
+                        1.0 * (1.0 - dynamics) + level * dynamics :
+                        level + (1.0 - level) * (1.0 - dynamics)
+                );
+            }
+        }
+        else // Trigger is open, check for release
+        {
+            if ((level <= close_thresh) && (angle <= 0)) // Signal is falling, close trigger
+            {
+                if ((release--) <= 0)
+                    state = TRG_STATE_CLOSED;
+            }
+            else // Reset release sample counter
+                release = rel_samples;
+        }
+
+        // Render samples
+        float render = 0.0;
+        for (size_t p = 0; p < playbacks; )
+        {
+            trigger_playback_t *pb = &playback[p];
+
+            // Check that index is not out of bound
+            if ((pb->offset >= t_sample->samples) || (pb->offset >= pb->limit))
+            {
+                // Remove finished playback
+                for (size_t r = p+1; r < playbacks; r++)
+                    playback[r-1] = playback[r];
+
+                // Decrement number of playbacks
+                playbacks--;
+            }
+            else
+            {
+                // Get sample & increment index
+                if ((track < (ssize_t)t_sample->channels) && (track >= 0))
+                    render += t_sample->frames[pb->offset * t_sample->channels + track] * pb->gain;
+                pb->offset++;
+
+                // Increment playback calculation index
+                p++;
+            }
+        }
+
+        // This is real output
+        out[i] = (sample * dry + render * wet) * out_gain;
+
+        if (mtr_out < out[i])
+            mtr_out = out[i];
+    }
+}
+
+//-----------------------------------------------------------------------------
+trigger_audio_module::trigger_audio_module()
+{
+    status_serial   = 1;
+    srate           = 0;
+}
+
+void trigger_audio_module::set_sample_rate(uint32_t sr)
+{
+    channels[0].change_sample_rate(sr);
+    channels[1].change_sample_rate(sr);
+
+    srate = sr;
+}
+
+void trigger_audio_module::params_changed()
+{
+    // Set-up knobs
+    for (size_t i=0; i<2; i++)
+    {
+        mono_trigger_t *t   = &channels[i];
+
+        t->lkp_samples      = *params[par_lookup] * srate * 0.001 ;
+        t->rel_samples      = *params[par_release] * srate * 0.001;
+        t->max_playbacks    = *params[par_sample_playbacks];
+        t->min_offset       = *params[par_sample_head] * srate * 0.001;
+        t->mode             = (*params[par_dyn_mode] > 0.5) ? 1 : 0;
+        t->open_thresh      = *params[par_open_threshold];
+        t->close_thresh     = *params[par_close_threshold];
+        t->dynamics         = *params[par_dyn_amount];
+        t->dry              = *params[par_dry];
+        t->wet              = *params[par_wet];
+        t->in_gain          = *params[par_in_gain];
+        t->out_gain         = *params[par_out_gain];
+
+        switch (size_t(*params[par_dyn_function]))
+        {
+            case 0: t->detector = linear_detector; break;
+            case 1: t->detector = sqrt_detector; break;
+            case 2: t->detector = quad_detector; break;
+        }
+    }
+
+    // Set-up files
+    if ((sample.frames != NULL) && (sample.channels > 0))
+    {
+        if (sample.channels > *params[par_sample_track_l])
+        {
+            channels[0].track       = *params[par_sample_track_l];
+            channels[0].max_offset  = *params[par_sample_tail] * sample.samples;
+        }
+        else
+            channels[0].mute();
+
+        if (sample.channels > *params[par_sample_track_r])
+        {
+            channels[1].track       = *params[par_sample_track_r];
+            channels[1].max_offset  = *params[par_sample_tail] * sample.samples;
+        }
+        else
+            channels[1].mute();
+    }
+    else
+    {
+        channels[0].mute();
+        channels[1].mute();
+    }
+}
+
+uint32_t trigger_audio_module::process(uint32_t offset, uint32_t nsamples, uint32_t inputs_mask, uint32_t outputs_mask)
+{
+    float mtr_input[2], mtr_output[2];
+    mtr_input[0]    = 0;
+    mtr_input[1]    = 0;
+    mtr_output[0]   = 0;
+    mtr_output[1]   = 0;
+
+    // Check bypass
+    if (*params[par_bypass] > 0.5f)
+    {
+        flash[0]    = 0;
+        flash[1]    = 0;
+
+        // everything bypassed
+        nsamples += offset;
+        while (offset < nsamples)
+        {
+            outs[0][offset] = ins[0][offset];
+            outs[1][offset] = ins[1][offset];
+            ++offset;
+        }
+    }
+    else
+    {
+        // Call trigger processing
+        for (size_t i=0; i<2; i++)
+        {
+            flash[i] -= std::min(flash[i], nsamples);
+
+            mono_trigger_t *t = &channels[i];
+
+            t->process(&ins[i][offset], &outs[i][offset], &sample, nsamples);
+
+            // Update meters & flashing
+            mtr_input[i]    = t->mtr_in;
+            mtr_output[i]   = t->mtr_out;
+
+            if ((t->fired) || (t->state != TRG_STATE_CLOSED))
+                flash[i] = srate >> 3;
+        }
+    }
+
+    SET_IF_CONNECTED(mtr_input_l, mtr_input[0]);
+    SET_IF_CONNECTED(mtr_input_r, mtr_input[1]);
+    SET_IF_CONNECTED(mtr_output_l, mtr_output[0]);
+    SET_IF_CONNECTED(mtr_output_r, mtr_output[1]);
+    SET_IF_CONNECTED(flash_l, flash[0]);
+    SET_IF_CONNECTED(flash_r, flash[1]);
+
+    return outputs_mask;
+}
+
+trigger_audio_module::~trigger_audio_module()
+{
+}
+
+void trigger_audio_module::send_configures(send_configure_iface *sci)
+{
+    sci->send_configure("file", sample.filename.c_str());
+}
+
+int trigger_audio_module::send_status_updates(send_updates_iface *sui, int last_serial)
+{
+    if (status_serial != last_serial)
+    {
+        sui->send_status("file", sample.filename.c_str());
+    }
+    return status_serial;
+}
+
+char *trigger_audio_module::configure(const char *key, const char *value)
+{
+    if (strcmp(key, "file") == 0)
+    {
+        channels[0].mute();
+        channels[1].mute();
+
+        sample.load(value);
+
+        params_changed();
+    }
+
+    return NULL;
+}
+
+#endif


### PR DESCRIPTION
Calf Trigger:

» Functionality «

This plugin implements simple triggering module. If your kick/toms/snare or other stuff was badly recorded (our regrets...) you can fix it by using this plugin. Just load good sample, configure this plugin and enjoy. Output signal may have some delay.
» Controls «

Input: Input signal level
Bypass: Bypass signal
Look-ahead: Signal level detection time
Open threshold: The threshold of input signal that makes trigger to begin to turn on
Close threshold: The threshold of input signal that makes trigger to begn to turn off
Release: The time trigger keeps turned on after input signal reached close threhold
Dynamics mode: The algorithms of level and attack detection
Dynamics: The dynamics of triggered signal
Dry: Amount of dry (unprocessed) signal
Wet: Amount of wet (processed) signal
File: Sample file to play when trigger turns on
Tracks (L/R): Number of track of sample file to play in left and right channels
Head cutoff: Number of milliseconds to cut from heading of sample (for example, when there is silence at the head)
Tail: The overall length of sample to use
Playbacks: Maximum number of sample playbacks at the same time.
Volume: Output volume

Patch is in attachment.
Here is the demo:
http://www.youtube.com/watch?v=Yhgu4tm2754

Now currently known problems:
1. Not very stable level detection. Trigger can pass some instrument peaks or trigger where it is not necessary. I think this is a bit for future work. Perhaps trigger needs also velocity threshold to be added.
2. Calf plugins still do not save references to file. This can be reached with LV2 State extension but... I'm not sure that can implement this feature properly. So I need to discuss it with main Calf developers. Please email me - sadko4u [at] gmail.

Thanks.
