### PR TITLE
make dist: add some missing files

### DIFF
--- a/gui/Makefile.am
+++ b/gui/Makefile.am
@@ -1,6 +1,7 @@
 SRCDIRS = icons/LV2 
 SUBDIRS = $(SRCDIRS)
 STYLES = $(wildcard $(srcdir)/styles/*)
+EXTRA_DIST = $(wildcard $(srcdir)/styles) $(wildcard $(srcdir)/strips) $(wildcard $(srcdir)/gui)
 
 install-data-hook:
 	$(top_builddir)/src/calfmakerdf -m gui -p $(DESTDIR)$(pkgdatadir)

--- a/src/calf/Makefile.am
+++ b/src/calf/Makefile.am
@@ -1,6 +1,6 @@
 noinst_HEADERS = audio_fx.h benchmark.h biquad.h buffer.h bypass.h \
     ctl_notebook.h ctl_combobox.h ctl_fader.h ctl_frame.h ctl_meterscale.h ctl_buttons.h \
-    ctl_phasegraph.h ctl_tuner.h ctl_linegraph.h \
+    ctl_phasegraph.h ctl_tuner.h ctl_linegraph.h ctl_pattern.h \
     ctl_curve.h ctl_keyboard.h ctl_knob.h ctl_led.h ctl_tube.h ctl_vumeter.h drawingutils.h \
     connector.h delay.h envelope.h fft.h fixed_point.h giface.h gtk_session_env.h gtk_main_win.h \
     gui.h gui_config.h gui_controls.h inertia.h jackhost.h \


### PR DESCRIPTION
Some files were missing from the tarball created by make dist in the git repo.
I don't know if all the files added are required, but at least now I can compile the tarball.