### PR TITLE
Fix compiling without USE_LV2

### DIFF
--- a/src/lv2wrap.cpp
+++ b/src/lv2wrap.cpp
@@ -1,9 +1,9 @@
 #include <config.h>
 #include "calf/lv2wrap.h"
 
-using namespace calf_plugins;
-
 #if USE_LV2
+
+using namespace calf_plugins;
 
 lv2_instance::lv2_instance(audio_module_iface *_module)
 {


### PR DESCRIPTION
compiling without LV2 shows the following error:

```
clang: warning: optimization flag '-finline-limit=80' is not supported
clang: warning: optimization flag '-finline-functions' is not supported
clang: warning: optimization flag '-finline-functions-called-once' is not supported
clang: warning: argument unused during compilation: '-finline-limit=80'
clang: warning: argument unused during compilation: '-finline-functions'
clang: warning: argument unused during compilation: '-finline-functions-called-once'
lv2wrap.cpp:5:17: error: expected namespace name
using namespace calfplugins;
```

This PR fixes that problem.