### PR TITLE
Test if linker supports nodelete

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,19 @@ else
 fi
 AC_MSG_RESULT($is_compiler_gcc)
 
+AC_MSG_CHECKING([whether the linker supports -z,nodelete])
+save_LDFLAGS="$LDFLAGS"
+LDFLAGS="$LDFLAGS -Wl,-z,nodelete"
+AC_RUN_IFELSE([AC_LANG_PROGRAM([[]],
+    [[]])],
+    [linker_supports_nodelete="yes"],
+    [linker_supports_nodelete="no"],
+    [linker_supports_nodelete="no"])
+AC_MSG_RESULT([$linker_supports_nodelete])
+LDFLAGS="$save_LDFLAGS"
+
+AM_CONDITIONAL(HAVE_LD_NODELETE, test "$linker_supports_nodelete" = "yes")
+
 ############################################################################################
 # Compute status shell variables
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -55,10 +55,15 @@ pkglib_LTLIBRARIES += libcalflv2gui.la
 libcalflv2gui_la_SOURCES = gui.cpp gui_config.cpp gui_controls.cpp ctl_curve.cpp ctl_keyboard.cpp ctl_knob.cpp ctl_led.cpp ctl_tube.cpp ctl_vumeter.cpp ctl_frame.cpp ctl_fader.cpp ctl_buttons.cpp ctl_notebook.cpp ctl_meterscale.cpp ctl_combobox.cpp ctl_tuner.cpp ctl_phasegraph.cpp ctl_pattern.cpp metadata.cpp giface.cpp plugin_gui_window.cpp preset.cpp preset_gui.cpp lv2gui.cpp osctl.cpp utils.cpp ctl_linegraph.cpp drawingutils.cpp
 
 if USE_DEBUG
-libcalflv2gui_la_LDFLAGS = -rpath $(lv2dir) -avoid-version -module -lexpat $(GUI_DEPS_LIBS) -disable-static  -Wl,-z,nodelete
+libcalflv2gui_la_LDFLAGS = -rpath $(lv2dir) -avoid-version -module -lexpat $(GUI_DEPS_LIBS) -disable-static
 else
-libcalflv2gui_la_LDFLAGS = -rpath $(lv2dir) -avoid-version -module -lexpat -export-symbols-regex "lv2ui_descriptor" $(GUI_DEPS_LIBS) -disable-static  -Wl,-z,nodelete
+libcalflv2gui_la_LDFLAGS = -rpath $(lv2dir) -avoid-version -module -lexpat -export-symbols-regex "lv2ui_descriptor" $(GUI_DEPS_LIBS) -disable-static
 endif
+
+if HAVE_LD_NODELETE
+libcalflv2gui_la_LDFLAGS += -Wl,-z,nodelete
+endif
+
 endif
 
 endif


### PR DESCRIPTION
The Mac OS linker does not support `-z,nodelete` so I added an check for that and omitted this flag to make calf compile on OS X.
