### PR TITLE
makerdf: fix preset file name in manifest

### DIFF
--- a/src/makerdf.cpp
+++ b/src/makerdf.cpp
@@ -459,7 +459,7 @@ void make_ttl(string path_prefix, const string *data_dir)
             + ">";
         ttl += uri + " a lv2p:Preset ;\n"
             "    lv2:appliesTo " + ilm->second.second + " ;\n"
-            "    rdfs:seeAlso <presets-" + pr.plugin + ".ttl> .\n";
+            "    rdfs:seeAlso <presets-" + ilm->second.first + ".ttl> .\n";
         
         presets_ttl += uri + 
             " a lv2p:Preset ;\n"


### PR DESCRIPTION
We have to use label from ladspa_plugin_info (e.g 'Filter') instead of name
set in presets.xml (e.g 'filter').

Fixes:

| Error opening file /usr/lib/lv2/calf.lv2/presets-filter.ttl (No such file or directory)
| lilv_world_load_file(): error: Error loading file `file:///usr/lib/lv2/calf.lv2/presets-filter.ttl'
| Error opening file /usr/lib/lv2/calf.lv2/presets-filter.ttl (No such file or directory)
| lilv_world_load_file(): error: Error loading file `file:///usr/lib/lv2/calf.lv2/presets-filter.ttl'
| Error opening file /usr/lib/lv2/calf.lv2/presets-filter.ttl (No such file or directory)
| lilv_world_load_file(): error: Error loading file `file:///usr/lib/lv2/calf.lv2/presets-filter.ttl'
| Error opening file /usr/lib/lv2/calf.lv2/presets-flanger.ttl (No such file or directory)
...

After fixing I could select presets from within muse.

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>