### PR TITLE
fix various memory errors and warnings

### DIFF
--- a/src/analyzer.cpp
+++ b/src/analyzer.cpp
@@ -89,6 +89,7 @@ analyzer::~analyzer()
     free(fft_outL);
     free(fft_inR);
     free(fft_inL);
+    free(fft_buffer);
     free(spline_buffer);
 }
 void analyzer::set_sample_rate(uint32_t sr) {

--- a/src/audio_fx.cpp
+++ b/src/audio_fx.cpp
@@ -1347,7 +1347,6 @@ resampleN::resampleN()
 }
 resampleN::~resampleN()
 {
-    free(tmp);
 }
 void resampleN::set_params(uint32_t sr, int fctr = 2, int fltrs = 2)
 {

--- a/src/audio_fx.cpp
+++ b/src/audio_fx.cpp
@@ -608,6 +608,9 @@ lookahead_limiter::lookahead_limiter() {
     asc_pos = -1;
     asc_changed = false;
     asc_coeff = 1.f;
+    buffer = NULL;
+    nextpos = NULL;
+    nextdelta = NULL;
 }
 lookahead_limiter::~lookahead_limiter()
 {

--- a/src/calf/connector.h
+++ b/src/calf/connector.h
@@ -28,7 +28,7 @@
 
 namespace calf_plugins {
 
-class plugin_strip;
+struct plugin_strip;
 class calf_connector;
 
 struct connector_port

--- a/src/calf/gui.h
+++ b/src/calf/gui.h
@@ -212,8 +212,8 @@ public:
     static void xml_element_end(void *data, const char *element);
 };
 
-class main_window_iface;
-class main_window_owner_iface;
+struct main_window_iface;
+struct main_window_owner_iface;
 
 /// A class used to inform the plugin GUIs about the environment they run in
 /// (currently: what plugin features are accessible)

--- a/src/calf/lv2wrap.h
+++ b/src/calf/lv2wrap.h
@@ -227,6 +227,7 @@ struct lv2_wrapper
     static void cb_cleanup(LV2_Handle Instance)
     {
         instance *const mod = (instance *)Instance;
+        delete mod->module;
         delete mod;
     }
 

--- a/src/calf/osc.h
+++ b/src/calf/osc.h
@@ -206,7 +206,9 @@ struct waveform_family: public std::map<uint32_t, float *>
             float *wf = new float[SIZE+1];
             bl.make_waveform(wf, cutoff, foldover);
             wf[SIZE] = wf[0];
-            (*this)[base * (top / cutoff)] = wf;
+            float **storage = &(*this)[base * (top / cutoff)];
+            delete[] *storage;
+            *storage = wf;
             cutoff = (int)(0.75 * cutoff);
         }
     }

--- a/src/calf/preset.h
+++ b/src/calf/preset.h
@@ -27,8 +27,8 @@
 
 namespace calf_plugins {
 
-class plugin_ctl_iface;
-    
+struct plugin_ctl_iface;
+
 /// Contents of single preset
 struct plugin_preset
 {

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1549,7 +1549,7 @@ CALF_PORT_PROPS(transientdesigner) = {
     { 300.f,  1.f,   5000.f, 0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release_time", "Release Time" },
     { 0.f,   -1.f,   1.f,    0,  PF_FLOAT | PF_SCALE_PERC | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "release_boost", "Release Boost" },
     { 2000.f, 50.f,  5000.f, 0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "display", "Display" },
-    { pow(2.0,-12.0), pow(2.0,-12.0),1, 0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "display_threshold", "Threshold" },
+    { pow(2.0f,-12.0f), pow(2.0f,-12.0f),1, 0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "display_threshold", "Threshold" },
     { 0,      0,     100,     0,  PF_INT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_SAMPLES, NULL, "lookahead", "Lookahead" },
     { 0,     0,     3,      0,  PF_ENUM | PF_CTL_COMBO, transientdesigner_view_names, "view", "View Mode" },
     { 100,    20,20000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_HZ | PF_PROP_GRAPH, NULL, "hipass", "Highpass" },

--- a/src/modules_comp.cpp
+++ b/src/modules_comp.cpp
@@ -2490,6 +2490,7 @@ transientdesigner_audio_module::transientdesigner_audio_module() {
     transients.set_channels(channels);
     hp_f_old = hp_m_old = lp_f_old = lp_m_old = 0;
     redraw = false;
+    pbuffer = NULL;
 }
 transientdesigner_audio_module::~transientdesigner_audio_module()
 {

--- a/src/modules_filter.cpp
+++ b/src/modules_filter.cpp
@@ -936,6 +936,7 @@ xover_audio_module<XoverBaseClass>::xover_audio_module()
     is_active = false;
     srate = 0;
     redraw_graph = true;
+    buffer = NULL;
     crossover.init(AM::channels, AM::bands, 44100);
 }
 template<class XoverBaseClass>

--- a/src/modules_filter.cpp
+++ b/src/modules_filter.cpp
@@ -501,9 +501,11 @@ inline string equalizerNband_audio_module<BaseClass, has_lphp>::get_crosshair_la
     return frequency_crosshair_label(x, y, sx, sy, q, dB, name, note, cents, 128 * *params[AM::param_zoom], 0);
 }
 
+namespace calf_plugins {
 template class equalizerNband_audio_module<equalizer5band_metadata, false>;
 template class equalizerNband_audio_module<equalizer8band_metadata, true>;
 template class equalizerNband_audio_module<equalizer12band_metadata, true>;
+}
 
 /**********************************************************************
  * EQUALIZER 30 BAND
@@ -1064,9 +1066,11 @@ bool xover_audio_module<XoverBaseClass>::get_layers(int index, int generation, u
     return crossover.get_layers(index, generation, layers);
 }
 
+namespace calf_plugins {
 template class xover_audio_module<xover2_metadata>;
 template class xover_audio_module<xover3_metadata>;
 template class xover_audio_module<xover4_metadata>;
+}
 
 
 /**********************************************************************

--- a/src/modules_limit.cpp
+++ b/src/modules_limit.cpp
@@ -193,6 +193,7 @@ multibandlimiter_audio_module::multibandlimiter_audio_module()
     _sanitize           = false;
     is_active           = false;
     cnt = 0;
+    buffer = NULL;
     
     for(int i = 0; i < strips; i ++) {
         weight_old[i] = -1.f;
@@ -585,6 +586,7 @@ sidechainlimiter_audio_module::sidechainlimiter_audio_module()
     _sanitize           = false;
     is_active           = false;
     cnt = 0;
+    buffer = NULL;
     
     for(int i = 0; i < strips; i ++) {
         weight_old[i] = -1.f;

--- a/src/modules_tools.cpp
+++ b/src/modules_tools.cpp
@@ -41,6 +41,7 @@ using namespace calf_plugins;
 stereo_audio_module::stereo_audio_module() {
     active      = false;
     _phase      = -1;
+    buffer = NULL;
 }
 stereo_audio_module::~stereo_audio_module() {
     free(buffer);
@@ -256,6 +257,7 @@ mono_audio_module::mono_audio_module() {
     meter_outR  = 0.f;
     _phase      = -1.f;
     _sc_level   = 0.f;
+    buffer = NULL;
 }
 mono_audio_module::~mono_audio_module() {
     free(buffer);

--- a/src/modules_tools.cpp
+++ b/src/modules_tools.cpp
@@ -577,7 +577,8 @@ multibandenhancer_audio_module::multibandenhancer_audio_module()
 }
 multibandenhancer_audio_module::~multibandenhancer_audio_module()
 {
-    free(phase_buffer);
+    for (int i = 0; i < strips; i++)
+      free(phase_buffer[i]);
 }
 void multibandenhancer_audio_module::activate()
 {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -158,7 +158,7 @@ vector <direntry> list_directory(const string &path)
 {
     std::vector <direntry> out;
     DIR *dir;
-    class dirent *ent;
+    struct dirent *ent;
     dir = opendir(path.empty() ? "." : path.c_str());
     while ((ent = readdir(dir)) != NULL) {
         direntry f;


### PR DESCRIPTION
Hello. I am in the middle of programming lv2 hosting software, and my goal is to contribute some fixes to free software fx libraries as I encounter issues.

I propose a set of patches to fix memory errors in Calf plugins, made with the help of Valgrind.
I run plugin collections in multiple scenarios: instanciate/deactivate right away, activate/desactivate once or several times in a row.
I have traced and fixed the errors, and this patch results in a clean Valgrind log.

I have found in particular that lv2 effects never had their modules freed properly. I noted the leak memory can go up to 40MB in one particular case.

Some commits are not related, errors and warnings happened when I set the compiler standard to C++1x, and these modifications fix them.