### PR TITLE
init the pointer urid_map that may cause a crash

### DIFF
--- a/src/lv2gui.cpp
+++ b/src/lv2gui.cpp
@@ -109,16 +109,17 @@ struct plugin_proxy_base
 };
 
 plugin_proxy_base::plugin_proxy_base(const plugin_metadata_iface *metadata, LV2UI_Write_Function wf, LV2UI_Controller c, const LV2_Feature* const* features)
+  : instance_handle(NULL),
+    data_access(NULL),
+    urid_map(NULL),
+    instance(NULL),
+    ext_ui_host(NULL)
 {
     plugin_metadata = metadata;
     
     write_function = wf;
     controller = c;
-
-    instance = NULL;
-    instance_handle = NULL;
-    data_access = NULL;
-    ext_ui_host = NULL;
+    
     atom_present = true; // XXXKF
     
     param_count = metadata->get_param_count();


### PR DESCRIPTION
Here is the backtrace of the crash on using the plugin in Ardour.  Event if the pointer urid_map is verified, it is not initialized in the constructor, so it can cause a crash.

#0  plugin_proxy_base::map_urid (this=0x559f26982f58, uri=0x559f26c87470 "urn:calf:preset_key_set") at lv2gui.cpp:181
#1  0x00007f9d2e2c0bbd in plugin_proxy_base::configure (this=0x559f26982f58, key=0x559f190349c0 "preset_key_set", value=0x559f26c87670 "0") at lv2gui.cpp:209
#2  0x00007f9d2e288f76 in calf_plugins::combo_box_param_control::combo_value_changed (widget=<optimized out>, value=0x559f17544120) at gui_controls.cpp:341
#3  0x00007f9d9f26cf75 in g_closure_invoke () from /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#4  0x00007f9d9f27ef82 in ?? () from /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#5  0x00007f9d9f287bdc in g_signal_emit_valist () from /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#6  0x00007f9d9f287fbf in g_signal_emit () from /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#7  0x00007f9d9e5a450b in ?? () from /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0
#8  0x00007f9d9e5a7198 in gtk_combo_box_set_active_iter () from /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0
#9  0x00007f9d2e28e84b in calf_plugins::combo_box_param_control::send_status (this=0x559f17544120, key=0x7ffc2f016460 "preset_key", value=0x7ffc2f016480 "0") at gui_controls.cpp:388
#10 0x00007f9d2e2784a9 in calf_plugins::plugin_gui::send_status (this=0x559f269ed120, key=0x7ffc2f016460 "preset_key", value=0x7ffc2f016480 "0") at gui.cpp:249
#11 0x00007f9d3cde31cf in calf_plugins::fluidsynth_audio_module::send_status_updates (this=0x559f1b560180, sui=0x559f269ed128, last_serial=<optimized out>) at fluidsynth.cpp:244
#12 0x00007f9d2e27c70b in calf_plugins::plugin_gui::create_from_xml (this=0x559f269ed120, _plugin=<optimized out>, 
    xml=0x559f2552b5c0 "<table rows=\"2\" cols=\"3\">\n    <vbox attach-x=\"0\" attach-y=\"0\" pad-x=\"10\" expand-y=\"1\" fill-y=\"0\" spacing=\"5\">\n        <label param=\"master\"  />\n        <knob param=\"master\" size=\"5\" ticks=\"0 0.0625 0."...) at gui.cpp:225
#13 0x00007f9d2e2c196f in gui_instantiate (descriptor=<optimized out>, plugin_uri=<optimized out>, bundle_path=<optimized out>, write_function=
    0x559f14f95d1e <LV2PluginUI::write_from_ui(void*, unsigned int, unsigned int, unsigned int, void const*)>, controller=0x559f17532c00, widget=0x559f269a4190, features=0x559f2636bc30) at lv2gui.cpp:360
#14 0x00007f9d9a4953fc in suil_instance_new () from /usr/lib/x86_64-linux-gnu/libsuil-0.so.0
#15 0x0000559f14f977d3 in LV2PluginUI::lv2ui_instantiate (this=0x559f17532c00, title="gtk2gui") at ../gtk2_ardour/lv2_plugin_ui.cc:336
#16 0x0000559f14f98ceb in LV2PluginUI::on_window_show (this=0x559f17532c00, title="Viola: Calf Fluidsynth (by Calf Studio Gear)") at ../gtk2_ardour/lv2_plugin_ui.cc:545
#17 0x0000559f14bed77d in PluginUIWindow::on_show (this=0x559f175183c0) at ../gtk2_ardour/plugin_ui.cc:195
#18 0x00007f9d9c71b82d in Gtk::Widget_Class::show_callback(_GtkWidget*) () from /usr/lib/x86_64-linux-gnu/libgtkmm-2.4.so.1
#19 0x00007f9d9f26cf75 in g_closure_invoke () from /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0

