### PR TITLE
small update to make fluxbox able to separate calf instances

### DIFF
--- a/src/gtk_main_win.cpp
+++ b/src/gtk_main_win.cpp
@@ -745,7 +745,9 @@ void gtk_main_window::create()
     register_icons();
     toplevel = GTK_WINDOW(gtk_window_new (GTK_WINDOW_TOPLEVEL));
     std::string title = "Calf JACK Host";
-    gtk_window_set_title(toplevel, title.c_str()); //(owner->get_client_name() + " - Calf JACK Host").c_str());
+    if (!owner->get_client_name().empty())
+        title = title + " - " + owner->get_client_name();
+    gtk_window_set_title(toplevel, title.c_str());
     gtk_window_set_icon_name(toplevel, "calf");
     gtk_window_set_role(toplevel, "calf_rack");
     

--- a/src/gtk_main_win.cpp
+++ b/src/gtk_main_win.cpp
@@ -19,6 +19,7 @@
  */
  
 #include <calf/gtk_main_win.h>
+#include <X11/Xutil.h>
 
 using namespace calf_plugins;
 using namespace std;
@@ -746,11 +747,15 @@ void gtk_main_window::create()
     toplevel = GTK_WINDOW(gtk_window_new (GTK_WINDOW_TOPLEVEL));
     std::string title = "Calf JACK Host";
     if (!owner->get_client_name().empty())
-        title = title + " - " + owner->get_client_name();
+        title = title + " - session: " + owner->get_client_name();
     gtk_window_set_title(toplevel, title.c_str());
     gtk_window_set_icon_name(toplevel, "calf");
     gtk_window_set_role(toplevel, "calf_rack");
-    
+    //due to https://developer.gnome.org/gtk2/stable/GtkWindow.html
+    //gtk_window_set_wmclass (). even though it says not to use this
+    //function, it is the only way to get primitive WMs like fluxbox
+    //to separate calf instances so that it can remember different positions.
+    gtk_window_set_wmclass(toplevel, title.c_str(), "calfjackhost");
     
     load_style((PKGLIBDIR "styles/" + get_config()->style).c_str());
     

--- a/src/gtk_main_win.cpp
+++ b/src/gtk_main_win.cpp
@@ -19,7 +19,6 @@
  */
  
 #include <calf/gtk_main_win.h>
-#include <X11/Xutil.h>
 
 using namespace calf_plugins;
 using namespace std;
@@ -755,6 +754,9 @@ void gtk_main_window::create()
     //gtk_window_set_wmclass (). even though it says not to use this
     //function, it is the only way to get primitive WMs like fluxbox
     //to separate calf instances so that it can remember different positions.
+    //Unlike what is stated there gtk_window_set_role() is not 
+    //interpreted correctly by fluxbox and thus wmclass call is not
+    //yet obsolete
     gtk_window_set_wmclass(toplevel, title.c_str(), "calfjackhost");
     
     load_style((PKGLIBDIR "styles/" + get_config()->style).c_str());


### PR DESCRIPTION
Hi there,
this bunch of commits is a minor change in calf so that primitive window managers (such as fluxbox where I had this problem, fixed and tested it) can separate across CALF instances. This way they can remember individual window positions and perhaps workspaces as well should that be required by the user. 
Unlike what is suggested by https://developer.gnome.org/gtk2/stable/GtkWindow.html#gtk-window-set-wmclass , the gtk_window_set_role () does not seem to be interpreted correctly by fluxbox window manager, which uses the X_hints fields "class" and "name" to separate across instances.