### PR TITLE
Clarify the units for line-graphs and dynamics thresholds:

### DIFF
--- a/src/calf/giface.h
+++ b/src/calf/giface.h
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General
  * Public License along with this program; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, 
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA 02111-1307, USA.
  */
 #ifndef CALF_GIFACE_H
@@ -37,7 +37,7 @@ namespace calf_plugins {
 enum {
     MAX_SAMPLE_RUN = 256
 };
-    
+
 struct automation_range;
 
 /// Values ORed together for flags field in parameter_properties
@@ -49,7 +49,7 @@ enum parameter_flags
   PF_BOOL = 0x0002,  ///< bool value (usually >=0.5f is treated as TRUE, which is inconsistent with LV2 etc. which treats anything >0 as TRUE)
   PF_ENUM = 0x0003,  ///< enum value (min, min+1, ..., max, only guaranteed to work when min = 0)
   PF_ENUM_MULTI = 0x0004, ///< SET / multiple-choice
-  
+
   PF_SCALEMASK = 0xF0, ///< bit mask for scale
   PF_SCALE_DEFAULT = 0x00, ///< no scale given
   PF_SCALE_LINEAR = 0x10, ///< linear scale
@@ -70,7 +70,7 @@ enum parameter_flags
   PF_CTL_METER  =     0x000700, ///< volume meter
   PF_CTL_LED    =     0x000800, ///< light emitting diode
   PF_CTL_LABEL  =     0x000900, ///< label
-  
+
   PF_CTLOPTIONS     = 0x00F000, ///< bit mask for control (widget) options
   PF_CTLO_HORIZ     = 0x001000, ///< horizontal version of the control (unused)
   PF_CTLO_VERT      = 0x002000, ///< vertical version of the control (unused)
@@ -87,6 +87,7 @@ enum parameter_flags
 
   PF_UNITMASK     = 0x0F000000,  ///< bit mask for units   \todo reduce to use only 5 bits
   PF_UNIT_DB      = 0x01000000,  ///< decibels
+  PF_UNIT_DBFS      = 0x0E000000,  ///< decibels relative to Full Scale
   PF_UNIT_COEF    = 0x02000000,  ///< multiply-by factor
   PF_UNIT_HZ      = 0x03000000,  ///< Hertz
   PF_UNIT_SEC     = 0x04000000,  ///< second
@@ -98,7 +99,7 @@ enum parameter_flags
   PF_UNIT_NOTE    = 0x0A000000,  ///< MIDI note number
   PF_UNIT_RPM     = 0x0B000000,  ///< revolutions per minute
   PF_UNIT_SAMPLES = 0x0C000000,  ///< samples
-  
+
   PF_SYNC_BPM     = 0x10000000, ///< sync a bpm setting with the host environment
 
   PF_DIGITMASK    = 0xE0000000,
@@ -205,7 +206,7 @@ struct line_graph_iface
     /// @retval true graph data was returned; subindex+1 graph may or may not be available
     /// @retval false graph data was not returned; subindex+1 graph does not exist either
     virtual bool get_graph(int index, int subindex, int phase, float *data, int points, cairo_iface *context, int *mode = 0) const { return false; }
-    
+
     /// Obtain subindex'th moving surface of parameter 'index'
     /// @param index parameter/dot number (usually tied to particular plugin control port)
     /// @param subindex mvoing line number (there may be multiple graphs for one parameter)
@@ -214,33 +215,33 @@ struct line_graph_iface
     /// @param x number of points direction to fill in x
     /// @param y number of points direction to fill in y
     virtual bool get_moving(int index, int subindex, int &direction, float *data, int x, int y, int &offset, uint32_t &color) const { return false; }
-    
+
     /// Obtain subindex'th dot of parameter 'index'
     /// @param index parameter/dot number (usually tied to particular plugin control port)
     /// @param subindex dot number (there may be multiple dots graphs for one parameter)
     /// @param phase 0 if in cache phase or 1 if in realtime phase
     virtual bool get_dot(int index, int subindex, int phase, float &x, float &y, int &size, cairo_iface *context) const { return false; }
-    
+
     /// Obtain subindex'th dot of parameter 'index'
     /// @param index parameter/dot number (usually tied to particular plugin control port)
     /// @param subindex dot number (there may be multiple dots graphs for one parameter)
     /// @param phase 0 if in cache phase or 1 if in realtime phase
     virtual bool get_gridline(int index, int subindex, int phase, float &pos, bool &vertical, std::string &legend, cairo_iface *context) const { return false; }
-    
+
     /// Retrun which layers need to be redrawn in the next GTK drawing cycle
     /// @param index Parameter/graph identifier (usually tied to particular plugin control port)
     /// @param generation The overall amount of drawing cycles since the last full refresh of all surfaces
     /// @param layers Bitmask defining the layers to be redrawn (see layers_flags above)
     /// @retval true there's at least one layer to be redrawn; false nothing to draw in this cycle
     virtual bool get_layers(int index, int generation, unsigned int &layers) const { return false; }
-    
+
     /// Return a label for the crosshairs they are enabled
     /// @param x Position of the mouse pointer in x direction
     /// @param y Position of the mouse pointer in y direction
     /// @param sx Horizontal size of the widget in pixels
     /// @param sy Vertical size of the widget in pixels
     virtual std::string get_crosshair_label( int x, int y, int sx, int sy, float q, int dB, int name, int note, int cents) const { std::string s = ""; return s; }
-    
+
     /// Standard destructor to make compiler happy
     virtual ~line_graph_iface() {}
 };
@@ -262,7 +263,7 @@ enum table_column_type
     TCT_LABEL, ///< string value (encoded as C-escaped string)
 };
 
-/// parameters of 
+/// parameters of
 struct table_column_info
 {
     const char *name; ///< column label
@@ -281,7 +282,7 @@ struct table_metadata_iface
 
     /// return the fixed number of rows, or 0 if the number of rows is variable
     virtual uint32_t get_table_rows() const = 0;
-    
+
     virtual ~table_metadata_iface() {}
 };
 
@@ -292,7 +293,7 @@ struct send_configure_iface
     /// @param key variable name
     /// @param value variable content
     virtual void send_configure(const char *key, const char *value) = 0;
-    
+
     virtual ~send_configure_iface() {}
 };
 
@@ -303,7 +304,7 @@ struct send_updates_iface
     /// @param key variable name
     /// @param value variable content
     virtual void send_status(const char *key, const char *value) = 0;
-    
+
     virtual ~send_updates_iface() {}
 };
 
@@ -416,10 +417,10 @@ struct plugin_ctl_iface
     virtual const phase_graph_iface *get_phase_graph_iface() const = 0;
     /// @return serial number of last automation write (JACK host only)
     virtual int get_write_serial(int param_no) { return 0; }
-    
+
     /// Add or update parameter automation routing
     virtual void add_automation(uint32_t source, const automation_range &dest) {}
-    /// Remove parameter automation routing        
+    /// Remove parameter automation routing
     virtual void delete_automation(uint32_t source, int param_no) {}
     /// Retrieve automation list for a given parameter
     /// @param param_no parameter to retrieve automation list for, or -1 for all
@@ -521,7 +522,7 @@ public:
     using Metadata::in_count;
     using Metadata::out_count;
     using Metadata::param_count;
-    float *ins[Metadata::in_count]; 
+    float *ins[Metadata::in_count];
     float *outs[Metadata::out_count];
     float *params[Metadata::param_count];
     bool questionable_data_reported_in;
@@ -574,7 +575,7 @@ public:
     void post_instantiate(uint32_t) {}
     /// Handle 'message context' port message
     /// @arg output_ports pointer to bit array of output port "changed" flags, note that 0 = first audio input, not first parameter (use input_count + output_count)
-    uint32_t message_run(const void *valid_ports, void *output_ports) { 
+    uint32_t message_run(const void *valid_ports, void *output_ports) {
         fprintf(stderr, "ERROR: message run not implemented\n");
         return 0;
     }
@@ -685,10 +686,10 @@ struct dssi_feedback_sender
     std::vector<int> indices;
     /// Source for the graph data (interface to marshal)
     const calf_plugins::line_graph_iface *graph;
-    
+
     /// Source for the graph data (interface to marshal)
     const calf_plugins::phase_graph_iface *phase;
-    
+
     /// Create using a new client
     dssi_feedback_sender(const char *URI, const line_graph_iface *_graph);
     dssi_feedback_sender(osctl::osc_client *_client, const line_graph_iface *_graph);
@@ -701,7 +702,7 @@ struct dssi_feedback_sender
 /// Metadata base class template, to provide default versions of interface functions
 template<class Metadata>
 class plugin_metadata: public plugin_metadata_iface
-{    
+{
 public:
     static const char *port_names[];
     static parameter_properties param_props[];
@@ -711,9 +712,9 @@ public:
     // These below are stock implementations based on enums and static members in Metadata classes
     // they may be overridden to provide more interesting functionality
 
-    const char *get_name() const { return Metadata::impl_get_name(); } 
-    const char *get_id() const { return Metadata::impl_get_id(); } 
-    const char *get_label() const { return Metadata::impl_get_label(); } 
+    const char *get_name() const { return Metadata::impl_get_name(); }
+    const char *get_id() const { return Metadata::impl_get_id(); }
+    const char *get_label() const { return Metadata::impl_get_label(); }
     int get_input_count() const { return Metadata::in_count; }
     int get_output_count() const { return Metadata::out_count; }
     int get_inputs_optional() const { return Metadata::ins_optional; }
@@ -742,11 +743,11 @@ public:
     static const char *impl_get_name() { return name; } \
     static const char *impl_get_id() { return id; } \
     static const char *impl_get_label() { return label; } \
-    
+
 extern const char *calf_copyright_info;
 
 bool get_freq_gridline(int subindex, float &pos, bool &vertical, std::string &legend, cairo_iface *context, bool use_frequencies = true, float res = 256, float ofs = 0.4);
-    
+
 /// convert amplitude value to normalized grid-ish value
 static inline float dB_grid(float amp, float res = 256, float ofs = 0.4)
 {
@@ -772,7 +773,7 @@ static inline float dB_grid_inv(float pos, float res = 256, float ofs = 0.4)
 }
 
 /// Line graph interface implementation for frequency response graphs
-class frequency_response_line_graph: public line_graph_iface 
+class frequency_response_line_graph: public line_graph_iface
 {
 public:
     mutable bool redraw_graph;
@@ -794,7 +795,7 @@ struct preset_access_iface
 {
     virtual void store_preset() = 0;
     virtual void activate_preset(int preset, bool builtin) = 0;
-    virtual ~preset_access_iface() {} 
+    virtual ~preset_access_iface() {}
 };
 
 /// Implementation of table_metadata_iface providing metadata for mod matrices
@@ -824,7 +825,7 @@ public:
 protected:
     /// Column descriptions for table widget
     table_column_info table_columns[6];
-    
+
     unsigned int matrix_rows;
 };
 
@@ -857,7 +858,7 @@ struct automation_range
     float min_value;
     float max_value;
     int param_no;
-    
+
     automation_range(float l, float u, int param)
     : min_value(l)
     , max_value(u)

--- a/src/giface.cpp
+++ b/src/giface.cpp
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU Lesser General
  * Public License along with this program; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, 
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
 #include <config.h>
@@ -55,7 +55,7 @@ automation_range *automation_range::new_from_configure(const plugin_metadata_ifa
     }
     from_controller = (uint32_t)atoi(from_ctl.c_str());
     key = totoken + 4;
-    
+
     size_t pcount = metadata->get_param_count();
     for (size_t i = 0; i < pcount; ++i) {
         const parameter_properties *props = metadata->get_param_props(i);
@@ -67,7 +67,7 @@ automation_range *automation_range::new_from_configure(const plugin_metadata_ifa
             return new automation_range(minv, maxv, i);
         }
     }
-    
+
     return NULL;
 }
 
@@ -153,7 +153,7 @@ float parameter_properties::get_increment() const
     float increment = 0.01;
     if (step > 1)
         increment = 1.0 / (step - 1);
-    else 
+    else
     if (step > 0 && step < 1)
         increment = step;
     else
@@ -206,10 +206,18 @@ std::string parameter_properties::to_string(float value) const
         return string(buf);
     }
     if ((flags & PF_SCALEMASK) == PF_SCALE_GAIN) {
-        if (value < 1.0 / 1024.0) // new bottom limit - 60 dB
-            return "-inf dB"; // XXXKF change to utf-8 infinity
-        snprintf(buf, sizeof(buf), "%0.1f dB", dsp::amp2dB(value));
-        return string(buf);
+        if ((flags & PF_UNITMASK) == PF_UNIT_DBFS) {
+            if (value < 1.0 / 1024.0) // new bottom limit - 60 dBFS
+                return "-inf dBFS"; // XXXKF change to utf-8 infinity
+            snprintf(buf, sizeof(buf), "%0.1f dBFS", dsp::amp2dB(value));
+            return string(buf);
+        }
+        else {
+            if (value < 1.0 / 1024.0) // new bottom limit - 60 dB
+                return "-inf dB"; // XXXKF change to utf-8 infinity
+            snprintf(buf, sizeof(buf), "%0.1f dB", dsp::amp2dB(value));
+            return string(buf);
+        }
     }
     std::string s_;
     switch(flags & PF_TYPEMASK)
@@ -252,9 +260,10 @@ std::string parameter_properties::to_string(float value) const
 
     if ((flags & PF_SCALEMASK) == PF_SCALE_LOG_INF && IS_FAKE_INFINITY(value))
         snprintf(buf, sizeof(buf), "∞"); // XXXKF change to utf-8 infinity
-    
+
     switch(flags & PF_UNITMASK) {
     case PF_UNIT_DB: return string(buf) + " dB";
+    case PF_UNIT_DBFS: return string(buf) + " dBFS";
     case PF_UNIT_HZ: return string(buf) + " Hz";
     case PF_UNIT_SEC: return string(buf) + " s";
     case PF_UNIT_MSEC: return string(buf) + " ms";
@@ -264,7 +273,7 @@ std::string parameter_properties::to_string(float value) const
     case PF_UNIT_RPM: return string(buf) + " rpm";
     case PF_UNIT_DEG: return string(buf) + " deg";
     case PF_UNIT_SAMPLES: return string(buf) + " smpl";
-    case PF_UNIT_NOTE: 
+    case PF_UNIT_NOTE:
         {
             static const char *notes = "C C#D D#E F F#G G#A A#B ";
             int note = (int)value;
@@ -357,7 +366,7 @@ bool calf_plugins::get_freq_gridline(int subindex, float &pos, bool &vertical, s
 
     if (!(subindex & 1)) {
         std::stringstream ss;
-        ss << (36 - 6 * subindex) << " dB";
+        ss << (36 - 6 * subindex) << " dBFS";
         legend = ss.str();
     }
     if (!legend.empty() and subindex != 6) {
@@ -437,11 +446,11 @@ bool frequency_response_line_graph::get_layers(int index, int generation, unsign
     return r;
 }
 std::string frequency_response_line_graph::get_crosshair_label(int x, int y, int sx, int sy, float q, int dB, int name, int note, int cents) const
-{ 
+{
     return frequency_crosshair_label(x, y, sx, sy, q, dB, name, note, cents);
 }
 std::string calf_plugins::frequency_crosshair_label(int x, int y, int sx, int sy, float q, int dB, int name, int note, int cents, double res, double ofs)
-{ 
+{
     std::stringstream ss;
     char str[1024];
     char tmp[1024];
@@ -492,7 +501,7 @@ const plugin_metadata_iface *calf_plugins::plugin_registry::get_by_uri(const cha
     {
         if (!strcmp(plugins[i]->get_plugin_info().label, label))
             return plugins[i];
-    }    
+    }
     return NULL;
 }
 
@@ -517,15 +526,15 @@ bool calf_plugins::parse_table_key(const char *key, const char *prefix, bool &is
     column = -1;
     if (0 != strncmp(key, prefix, strlen(prefix)))
         return false;
-    
+
     key += strlen(prefix);
-    
+
     if (!strcmp(key, "rows"))
     {
         is_rows = true;
         return true;
     }
-    
+
     const char *comma = strchr(key, ',');
     if (comma)
     {
@@ -533,9 +542,9 @@ bool calf_plugins::parse_table_key(const char *key, const char *prefix, bool &is
         column = atoi(comma + 1);
         return true;
     }
-    
+
     printf("Unknown key %s under prefix %s", key, prefix);
-    
+
     return false;
 }
 
@@ -581,7 +590,7 @@ void mod_matrix_metadata::get_configure_vars(std::vector<std::string> &names) co
             snprintf(buf, sizeof(buf), "mod_matrix:%d,%d", i, j);
             names.push_back(buf);
         }
-    }        
+    }
 }
 
 

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -47,7 +47,7 @@ const char *periodical_mode_names[] = {
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "bypass", "Bypass" }, \
     { 1,           0.015625,    64,    0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB | PF_PROP_NOBOUNDS, NULL, "level_in", "Input Gain" }, \
     { 1,           0.015625,    64,    0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB | PF_PROP_NOBOUNDS, NULL, "level_out", "Output Gain" },
-    
+
 #define METERING_PARAMS \
     { 0,           0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_inL", "Meter-InL" }, \
     { 0,           0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_inR", "Meter-InR" }, \
@@ -96,7 +96,7 @@ const char *periodical_mode_names[] = {
     { 500,       10,   2000,  1, PF_INT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "ms", "ms" }, \
     { 2,         0.01, 100,   0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_HZ, NULL, "hz", "Frequency" }, \
     { 120,       1,    300,   1, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_BPM | PF_SYNC_BPM, NULL, "bpm_host", "Host BPM" }, \
- 
+
 
 ////////////////////////////////////////////////////////////////////////////
 
@@ -413,7 +413,7 @@ CALF_PORT_PROPS(monocompressor) = {
     { 0,      0,  1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_out", "Output" },
     { 0,      0,  1,    0, PF_BOOL | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_in", "0dB-In" },
     { 0,      0,  1,    0, PF_BOOL | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_out", "0dB-Out" },
-    { 0.125,      0.000976563, 1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "threshold", "Threshold" },
+    { 0.125,      0.000976563, 1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS, NULL, "threshold", "Threshold" },
     { 2,      1, 20,  21, PF_FLOAT | PF_SCALE_LOG_INF | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "ratio", "Ratio" },
     { 20,     0.01, 2000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "attack", "Attack" },
     { 250,    0.01, 2000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release", "Release" },
@@ -442,7 +442,7 @@ CALF_PORT_PROPS(compressor) = {
     { 0,      0,  1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_out", "Output" },
     { 0,      0,  1,    0, PF_BOOL | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_in", "0dB-In" },
     { 0,      0,  1,    0, PF_BOOL | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_out", "0dB-Out" },
-    { 0.125,      0.000976563, 1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "threshold", "Threshold" },
+    { 0.125,      0.000976563, 1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS, NULL, "threshold", "Threshold" },
     { 2,      1, 20,  21, PF_FLOAT | PF_SCALE_LOG_INF | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "ratio", "Ratio" },
     { 20,     0.01, 2000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "attack", "Attack" },
     { 250,    0.01, 2000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release", "Release" },
@@ -483,7 +483,7 @@ CALF_PORT_PROPS(sidechaincompressor) = {
     { 0,      0,  1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_out", "Output" },
     { 0,      0,  1,    0, PF_BOOL | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_in", "0dB-In" },
     { 0,      0,  1,    0, PF_BOOL | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_out", "0dB-Out" },
-    { 0.125,      0.000976563, 1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "threshold", "Threshold" },
+    { 0.125,      0.000976563, 1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS, NULL, "threshold", "Threshold" },
     { 2,      1, 20,  21, PF_FLOAT | PF_SCALE_LOG_INF | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "ratio", "Ratio" },
     { 20,     0.01, 2000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "attack", "Attack" },
     { 250,    0.01, 2000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release", "Release" },
@@ -510,7 +510,7 @@ CALF_PLUGIN_INFO(sidechaincompressor) = { 0x8517, "SidechainCompressor", "Calf S
 
 ////////////////////////////////////////////////////////////////////////////
 #define MULTI_BAND_COMP_PARAMS(band1, band2) \
-    { 0.25,      0.000976563, 1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "threshold" #band1, "Threshold " #band2 }, \
+    { 0.25,      0.000976563, 1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS, NULL, "threshold" #band1, "Threshold " #band2 }, \
     { 2,           1,           20,    21, PF_FLOAT | PF_SCALE_LOG_INF | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "ratio" #band1, "Ratio " #band2 }, \
     { 150,          0.01,        2000,  0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "attack" #band1, "Attack " #band2 }, \
     { 300,         0.01,        2000,  0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release" #band1, "Release " #band2 }, \
@@ -559,7 +559,7 @@ CALF_PORT_PROPS(deesser) = {
     { 0,      0,  1,    0, PF_BOOL | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_out", "Out" },
     { 0,      0,  1,    0, PF_ENUM | PF_CTL_COMBO, deesser_detection_names, "detection", "Detection" },
     { 0,      0,  1,    0, PF_ENUM | PF_CTL_COMBO, deesser_mode_names, "mode", "Mode" },
-    { 0.125,  0.000976563, 1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "threshold", "Threshold" },
+    { 0.125,  0.000976563, 1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS, NULL, "threshold", "Threshold" },
     { 3,      1, 20,  21, PF_FLOAT | PF_SCALE_LOG_INF | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "ratio", "Ratio" },
     { 15,     1, 100,   1, PF_INT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "laxity", "Laxity" },
     { 1,      1, 64,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "makeup", "Makeup" },
@@ -567,7 +567,7 @@ CALF_PORT_PROPS(deesser) = {
     { 6000,   10,   18000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_HZ | PF_PROP_GRAPH, NULL, "f1_freq", "Split" },
     { 4500,   10,   18000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_HZ, NULL, "f2_freq", "Peak" },
     { 1,      0.0625,  16, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "f1_level", "Gain" },
-    { 4,      0.0625,  16, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "f2_level", "Level" },
+    { 4,      0.0625,  16, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS, NULL, "f2_level", "Level" },
     { 1,      0.1,     100,1, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "f2_q", "Peak Q" },
     { 0,      0,  1,    0, PF_BOOL | PF_CTL_TOGGLE, NULL, "sc_listen", "S/C-Listen" },
     {}
@@ -590,7 +590,7 @@ CALF_PORT_PROPS(gate) = {
     { 0,      0,  1,    0, PF_BOOL | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_in", "0dB-In" },
     { 0,      0,  1,    0, PF_BOOL | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_out", "0dB-Out" },
     { 0.06125,   0.000015849, 1, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "range", "Max Gain Reduction" },
-    { 0.125,      0.000976563, 1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "threshold", "Threshold" },
+    { 0.125,      0.000976563, 1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS, NULL, "threshold", "Threshold" },
     { 2,      1, 20,  21, PF_FLOAT | PF_SCALE_LOG_INF | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "ratio", "Ratio" },
     { 20,     0.01, 2000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "attack", "Attack" },
     { 250,    0.01, 2000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release", "Release" },
@@ -631,7 +631,7 @@ CALF_PORT_PROPS(sidechaingate) = {
     { 0,      0,  1,    0, PF_BOOL | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_in", "0dB-In" },
     { 0,      0,  1,    0, PF_BOOL | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_out", "0dB-Out" },
     { 0.06125,   0.000015849, 1, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "range", "Max Gain Reduction" },
-    { 0.125,      0.000976563, 1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "threshold", "Threshold" },
+    { 0.125,      0.000976563, 1,    0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS, NULL, "threshold", "Threshold" },
     { 2,      1, 20,  21, PF_FLOAT | PF_SCALE_LOG_INF | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "ratio", "Ratio" },
     { 20,     0.01, 2000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "attack", "Attack" },
     { 250,    0.01, 2000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release", "Release" },
@@ -658,7 +658,7 @@ CALF_PLUGIN_INFO(sidechaingate) = { 0x8504, "SidechainGate", "Calf Sidechain Gat
 ////////////////////////////////////////////////////////////////////////////
 #define MULTI_BAND_GATE_PARAMS(band1, band2) \
     { 0.06125,   0.000015849, 1, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "range" #band1, "Reduction " #band2 }, \
-    { 0.25,      0.000976563, 1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "threshold" #band1, "Threshold " #band2 }, \
+    { 0.25,      0.000976563, 1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS, NULL, "threshold" #band1, "Threshold " #band2 }, \
     { 2,           1,           20,    21, PF_FLOAT | PF_SCALE_LOG_INF | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "ratio" #band1, "Ratio " #band2 }, \
     { 150,          0.01,        2000,  0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "attack" #band1, "Attack " #band2 }, \
     { 300,         0.01,        2000,  0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release" #band1, "Release " #band2 }, \
@@ -698,7 +698,7 @@ CALF_PORT_NAMES(limiter) = {"In L", "In R", "Out L", "Out R"};
 CALF_PORT_PROPS(limiter) = {
     BYPASS_AND_LEVEL_PARAMS
     METERING_PARAMS
-    { 1,      0.0625, 1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "limit", "Limit" },
+    { 1,      0.0625, 1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS, NULL, "limit", "Limit" },
     { 5,         0.1,        10,  0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "attack", "Lookahead" },
     { 50,         1,        1000,  0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release", "Release" },
 
@@ -728,7 +728,7 @@ CALF_PORT_PROPS(multibandlimiter) = {
 
     { 1,      0,  1,    0, PF_ENUM | PF_CTL_COMBO, mb_crossover_filter_choices, "mode", "Filter Mode" },
 
-    { 1,      0.0625, 1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "limit", "Limit" },
+    { 1,      0.0625, 1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS, NULL, "limit", "Limit" },
     { 4,         0.1,        10,  0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "attack", "Lookahead" },
     { 30,         1,        1000,  0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release", "Release" },
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "minrel", "Min Release" },
@@ -763,9 +763,9 @@ CALF_PORT_PROPS(multibandlimiter) = {
     { 0,           0,           1,     0,  PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "asc_led", "asc active" },
 
     { 0.5f,      0.f,         1.f,   0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "asc_coeff", "ASC Level" },
-    
+
     { 1,           1,           4,   0,  PF_INT | PF_SCALE_LINEAR | PF_UNIT_COEF | PF_CTL_KNOB, NULL, "oversampling", "Oversampling" },
-    
+
     {}
 };
 
@@ -786,7 +786,7 @@ CALF_PORT_PROPS(sidechainlimiter) = {
 
     { 1,      0,  1,    0, PF_ENUM | PF_CTL_COMBO, mb_crossover_filter_choices, "mode", "Filter Mode" },
 
-    { 1,      0.0625, 1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "limit", "Limit" },
+    { 1,      0.0625, 1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS, NULL, "limit", "Limit" },
     { 4,         0.1,        10,  0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "attack", "Lookahead" },
     { 30,         1,        1000,  0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release", "Release" },
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "minrel", "Min Release" },
@@ -808,25 +808,25 @@ CALF_PORT_PROPS(sidechainlimiter) = {
     { -0.2f,      -1.f,         1.f,   0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "release2", "Release 3" },
     { -0.5f,      -1.f,         1.f,   0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "release3", "Release 4" },
     { -0.5f,      -1.f,         1.f,   0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "release_sc", "Release S/C" },
-    
+
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "solo0", "Solo 1" },
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "solo1", "Solo 2" },
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "solo2", "Solo 3" },
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "solo3", "Solo 4" },
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "solo_sc", "Solo S/C" },
-    
+
     { 1,         0.f,        1000,  0,  PF_FLOAT | PF_UNIT_MSEC | PF_PROP_OUTPUT, NULL, "effrelease0", "Effectively Release 1" },
     { 1,         0.f,        1000,  0,  PF_FLOAT | PF_UNIT_MSEC | PF_PROP_OUTPUT, NULL, "effrelease1", "Effectively Release 2" },
     { 1,         0.f,        1000,  0,  PF_FLOAT | PF_UNIT_MSEC | PF_PROP_OUTPUT, NULL, "effrelease2", "Effectively Release 3" },
     { 1,         0.f,        1000,  0,  PF_FLOAT | PF_UNIT_MSEC | PF_PROP_OUTPUT, NULL, "effrelease3", "Effectively Release 4" },
     { 1,         0.f,        1000,  0,  PF_FLOAT | PF_UNIT_MSEC | PF_PROP_OUTPUT, NULL, "effrelease_sc", "Effectively Release S/C" },
-    
+
     { 1,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "asc", "ASC" },
 
     { 0,           0,           1,     0,  PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "asc_led", "asc active" },
 
     { 0.5f,      0.f,         1.f,   0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "asc_coeff", "ASC Level" },
-    
+
     { 1,           1,           4,   0,  PF_INT | PF_SCALE_LINEAR | PF_UNIT_COEF | PF_CTL_KNOB, NULL, "oversampling", "Oversampling" },
     { 1,           0.015625,    64,    0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "level_sc", "Level S/C"},
     {}
@@ -1014,7 +1014,7 @@ CALF_PORT_PROPS(equalizer30band) = {
     GRAPHICEQ_BAND_PARAMS(228)
     GRAPHICEQ_BAND_PARAMS(229)
     GRAPHICEQ_BAND_PARAMS(230)
-    
+
     { 1,           0,  1, 0, PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "l_active", "L Active" },
     { 1,           0,  1, 0, PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "r_active", "R Active" },
     { 0,           0,  2, 0, PF_ENUM | PF_CTL_COMBO, equalizer30band_channel_modes, "linked", "Link Mode" },
@@ -1033,7 +1033,7 @@ CALF_PLUGIN_INFO(equalizer30band) = { 0x8514, "Equalizer30Band", "Calf Equalizer
     { 0.0,       0.0,        20.0,     0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "delay" #band, "Delay " #band }, \
     { 0,           0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_L" #band, "Level L " #band }, \
     { 0,           0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_R" #band, "Level R " #band },
-   
+
 ////////////////////////////////////////////////////////////////////////////
 
 CALF_PORT_NAMES(xover2) = {"In L", "In R", "Out 1 L", "Out 1 R", "Out 2 L", "Out 2 R"};
@@ -1098,7 +1098,7 @@ CALF_PLUGIN_INFO(xover4) = { 0x8515, "XOver4Band", "Calf X-Over 4 Band", "Calf S
     {           0,           0,  1, 0, PF_BOOL | PF_CTL_TOGGLE, NULL, "solo" #band, "Solo " #band }, \
     {           0,           0,  1, 0, PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "level" #band, "Level " #band }, \
     {           1,         0.25, 4, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "q" #band, "Q " #band },
-    
+
 const char *vocoder_analyzer_modes[] = {"Off", "Carrier", "Modulator", "Processed", "Output"};
 
 CALF_PORT_NAMES(vocoder) = {"In L", "In R", "Out L", "Out R"};
@@ -1107,38 +1107,38 @@ CALF_PORT_PROPS(vocoder) = {
     { 0,           0,  1, 0, PF_BOOL | PF_CTL_TOGGLE, NULL, "bypass", "Bypass" },
     { 1,           0,  1, 0, PF_BOOL | PF_CTL_TOGGLE, NULL, "link", "Link" },
     { 1,           0,  1, 0, PF_BOOL | PF_CTL_TOGGLE, NULL, "detectors", "Detectors" },
-    
+
     { 1, 0.015625,    64, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "carrier_in", "Carrier In" },
     { 0,           0,  1, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "carrier_inL", "Carrier In L" },
     { 0,           0,  1, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "carrier_inR", "Carrier In R" },
     { 0,           0,  1, 0, PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "carrier_clip_inL", "Carrier Clip In L" },
     { 0,           0,  1, 0, PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "carrier_clip_inR", "Carrier Clip In R" },
-    
+
     { 1, 0.015625,    64, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "mod_in", "Modulator In" },
     { 0,           0,  1, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "mod_inL", "Modulator In L" },
     { 0,           0,  1, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "mod_inR", "Modulator In R" },
     { 0,           0,  1, 0, PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "mod_clip_inL", "Modulator Clip In L" },
     { 0,           0,  1, 0, PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "mod_clip_inR", "Modulator Clip In R" },
-    
+
     { 1, 0.015625,    64, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "out", "Out" },
     { 0,           0,  1, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "outL", "Out L" },
     { 0,           0,  1, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "outR", "Out R" },
     { 0,           0,  1, 0, PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_outL", "Clip Out L" },
     { 0,           0,  1, 0, PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_outR", "Clip Out R" },
-    
+
     { 0,           0, 16, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "carrier", "Carrier" },
     { 0,           0, 16, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "modulator", "Modulator" },
     { 1, 0.000015849, 16, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "processed", "Processed" },
-    
+
     { 4,           2,  9, 0, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "order", "Isolation" },
     { 2,           0,  4, 0, PF_INT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "bands", "Bands" },
     { 0,           0,  1, 0, PF_BOOL | PF_CTL_TOGGLE , NULL, "hiq", "High-Q" },
-    
+
     {  5.f, 0.1f, 500.f,  0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "attack", "Attack" },
     { 50.f, 0.1f, 5000.f, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release", "Release" },
-    
+
     { 0,           0,  4, 0, PF_ENUM | PF_CTL_COMBO, vocoder_analyzer_modes, "analyzer", "Analyzer" },
-    
+
     VOCODER_BAND_PARAMS(1)
     VOCODER_BAND_PARAMS(2)
     VOCODER_BAND_PARAMS(3)
@@ -1171,11 +1171,11 @@ CALF_PORT_PROPS(vocoder) = {
     VOCODER_BAND_PARAMS(30)
     VOCODER_BAND_PARAMS(31)
     VOCODER_BAND_PARAMS(32)
-    
+
     { 20,    20, 20000, 0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_HZ, NULL, "lower", "Lower" },
     { 20000, 20, 20000, 0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_HZ, NULL, "upper", "Upper" },
     { 0,     -1,     1, 0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "tilt", "Tilt" },
-    
+
     {}
 };
 
@@ -1220,7 +1220,7 @@ CALF_PORT_PROPS(ringmodulator) = {
     { 0.5,         0,           1,     0,  PF_FLOAT | PF_SCALE_PERC | PF_UNIT_COEF | PF_CTL_KNOB, NULL, "mod_phase", "Mod Phase" },
     { 0,           -200,        200,  401, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_CENTS, NULL, "mod_detune", "Mod Detune" },
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "mod_listen", "Listen" },
-    
+
     { 0,           0,           4,     0,  PF_ENUM | PF_CTL_COMBO, ringmod_mode_names, "lfo1_mode", "LFO 1" },
     { 0.1,         0.01,        10,    0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_HZ, NULL, "lfo1_freq", "LFO 1 Freq" },
     { 0,           0,           1,     2,  PF_BOOL | PF_CTL_BUTTON , NULL, "lfo1_reset", "Reset 1" },
@@ -1231,7 +1231,7 @@ CALF_PORT_PROPS(ringmodulator) = {
     { 100,         -200,        200,  401, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_CENTS, NULL, "lfo1_mod_detune_hi", "Mod Detune HI" },
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "lfo1_mod_detune_active", "Mod Detune Active" },
     { 0,           0,           1,     0,  PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "lfo1_activity", "Activity 1" },
-    
+
     { 0,           0,           4,     0,  PF_ENUM | PF_CTL_COMBO, ringmod_mode_names, "lfo2_mode", "LFO 2" },
     { 0.2,         0.01,        10,    0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_HZ, NULL, "lfo2_freq", "LFO 2 Freq" },
     { 0,           0,           1,     2,  PF_BOOL | PF_CTL_BUTTON , NULL, "lfo2_reset", "Reset 2" },
@@ -1242,7 +1242,7 @@ CALF_PORT_PROPS(ringmodulator) = {
     { 0.6,         0,           1,     0,  PF_FLOAT | PF_SCALE_PERC, NULL, "lfo2_mod_amount_hi", "Mod Amount HI" },
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "lfo2_mod_amount_active", "Mod Amount Active" },
     { 0,           0,           1,     0,  PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "lfo2_activity", "Activity 2" },
-    
+
     {}
 };
 
@@ -1270,10 +1270,10 @@ CALF_PORT_PROPS(saturator) = {
     { 2000,       80,           8000,  0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_HZ, NULL, "p_freq", "Tone" },
     { 1,          0.0625,       16,    0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "p_level", "Amount" },
     { 1,          0.1,          10,    1,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "p_q", "Gradient" },
-    
+
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "pre", "Activate Pre" },
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "post", "Activate Post" },
-    
+
     {}
 };
 
@@ -1361,7 +1361,7 @@ CALF_PORT_PROPS(stereo) = {
     { 0.f,         -20.f,        20.f,  0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "delay", "Delay" },
 
     { 0.f,      0.f,           1.f,   0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_COEF | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_phase", "Phase Correlation" },
-    
+
     { 1,           1,           100,    0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_NOBOUNDS, NULL, "sc_level", "S/C Level" },
     { 0,        0, 360,  91, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_DEG, NULL, "stereo_phase", "Stereo Phase" },
     {}
@@ -1386,17 +1386,17 @@ CALF_PORT_PROPS(multibandenhancer) = {
     { 0.f,      -1.f,         1.f,   0, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF | PF_DIGIT_2, NULL, "base1", "Base 2" },
     { 0.f,      -1.f,         1.f,   0, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF | PF_DIGIT_2, NULL, "base2", "Base 3" },
     { 0.f,      -1.f,         1.f,   0, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF | PF_DIGIT_2, NULL, "base3", "Base 4" },
-    
+
     { 0,         0.0,         10,    0, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "drive0", "Harmonics 1" },
     { 0,         0.0,         10,    0, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "drive1", "Harmonics 2" },
     { 0,         0.0,         10,    0, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "drive2", "Harmonics 3" },
     { 0,         0.0,         10,    0, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "drive3", "Harmonics 4" },
-    
+
     { 0,        -10,          10,    0, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_FADER | PF_UNIT_COEF, NULL, "blend0", "Blend Harmonics 1" },
     { 0,        -10,          10,    0, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_FADER | PF_UNIT_COEF, NULL, "blend1", "Blend Harmonics 2" },
     { 0,        -10,          10,    0, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_FADER | PF_UNIT_COEF, NULL, "blend2", "Blend Harmonics 3" },
     { 0,        -10,          10,    0, PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_FADER | PF_UNIT_COEF, NULL, "blend3", "Blend Harmonics 4" },
-    
+
     { 0,         0,           1,     0, PF_BOOL | PF_CTL_TOGGLE, NULL, "solo0", "Solo 1" },
     { 0,         0,           1,     0, PF_BOOL | PF_CTL_TOGGLE, NULL, "solo1", "Solo 2" },
     { 0,         0,           1,     0, PF_BOOL | PF_CTL_TOGGLE, NULL, "solo2", "Solo 3" },
@@ -1445,7 +1445,7 @@ CALF_PORT_PROPS(haas_enhancer) = {
     METERING_PARAMS
     {    0,        0,    1,     0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_sideL", "Side L" },
     {    0,        0,    1,     0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_sideR", "Side R" },
-    
+
     {    2,        0,    4,     1, PF_ENUM | PF_CTL_COMBO, haas_enhancer_source, "m_source", "Middle source" },
     {  0.0,      0.0,  1.0,   1.0, PF_BOOL | PF_CTL_TOGGLE, NULL, "m_phase", "Middle phase" },
 
@@ -1510,7 +1510,7 @@ CALF_PORT_PROPS(analyzer) = {
     { 0,           0,           1,     0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_R", "Level R" },
     { 0,           0,           1,     0,  PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_L", "Clip L" },
     { 0,           0,           1,     0,  PF_FLOAT | PF_CTL_LED | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "clip_R", "Clip R" },
-    
+
     { 1.25,      0.5,           2,     0,  PF_FLOAT | PF_SCALE_PERC | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_NOBOUNDS, NULL, "analyzer_level", "Analyzer Level" },
     { 0,           0,          10,     0,  PF_ENUM | PF_CTL_COMBO, analyzer_mode_names, "analyzer_mode", "Analyzer Mode" },
     { 0,           0,           1,     2,  PF_ENUM | PF_CTL_COMBO, analyzer_scale_names, "analyzer_scale", "Analyzer Scale" },
@@ -1523,13 +1523,13 @@ CALF_PORT_PROPS(analyzer) = {
     { 1,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "analyzer_display", "Analyzer Display" },
     { 0,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "analyzer_hold", "Analyzer Hold" },
     { 0,           0,           1,     2,  PF_BOOL | PF_CTL_TOGGLE , NULL, "analyzer_freeze", "Analyzer Freeze" },
-    
+
     { 1,           0,           4,     0,  PF_ENUM | PF_CTL_COMBO, gonio_mode_names, "gonio_mode", "Gonio Mode" },
     { 1,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "gonio_use_fade", "Gonio Fade Active" },
     { 0.5f,      0.f,         1.f,     0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "gonio_fade", "Gonio Fade" },
     { 4,           1,           5,     0,  PF_INT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "gonio_accuracy", "Gonio Accuracy" },
     { 1,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "gonio_display", "Gonio Display" },
-    
+
     {}
 };
 
@@ -1545,11 +1545,11 @@ CALF_PORT_PROPS(transientdesigner) = {
     { 1,      0,     1,      0,  PF_FLOAT | PF_SCALE_PERC | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "mix", "Mix" },
     { 30.f,  1.f,   500.f,  0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "attack_time", "Attack Time" },
     { 0.f,   -1.f,   1.f,    0,  PF_FLOAT | PF_SCALE_PERC | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "attack_boost", "Attack Boost" },
-    { 1.f,    0.0009765625f, 1.f,    0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB | PF_PROP_GRAPH, NULL, "sustain_threshold", "Sustain Threshold" },
+    { 1.f,    0.0009765625f, 1.f,    0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS | PF_PROP_GRAPH, NULL, "sustain_threshold", "Sustain Threshold" },
     { 300.f,  1.f,   5000.f, 0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "release_time", "Release Time" },
     { 0.f,   -1.f,   1.f,    0,  PF_FLOAT | PF_SCALE_PERC | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "release_boost", "Release Boost" },
     { 2000.f, 50.f,  5000.f, 0,  PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_MSEC, NULL, "display", "Display" },
-    { pow(2.0f,-12.0f), pow(2.0f,-12.0f),1, 0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "display_threshold", "Threshold" },
+    { pow(2.0f,-12.0f), pow(2.0f,-12.0f),1, 0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DBFS | PF_PROP_GRAPH, NULL, "display_threshold", "Threshold" },
     { 0,      0,     100,     0,  PF_INT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_SAMPLES, NULL, "lookahead", "Lookahead" },
     { 0,     0,     3,      0,  PF_ENUM | PF_CTL_COMBO, transientdesigner_view_names, "view", "View Mode" },
     { 100,    20,20000, 0, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_HZ | PF_PROP_GRAPH, NULL, "hipass", "Highpass" },
@@ -1567,7 +1567,7 @@ CALF_PLUGIN_INFO(transientdesigner) = { 0x8588, "TransientDesigner", "Calf Trans
 #define VINYL_SYNTH(band) \
     { 0, -1, 1, 0, PF_FLOAT | PF_SCALE_PERC | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "pitch" #band, "Pitch " #band }, \
     {           0,           0,  1, 0, PF_BOOL | PF_CTL_TOGGLE, NULL, "active" #band, "Activate " #band },
-    
+
 CALF_PORT_NAMES(vinyl) = {"In L", "In R", "Out L", "Out R"};
 CALF_PORT_PROPS(vinyl) = {
     { 0,        0,      1, 0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "bypass", "Bypass" },
@@ -1578,7 +1578,7 @@ CALF_PORT_PROPS(vinyl) = {
     { 33,      33,     78, 1,  PF_INT | PF_CTL_KNOB | PF_UNIT_COEF , NULL, "speed", "Speed" },
     { 0,        0,      1, 0,  PF_FLOAT | PF_SCALE_PERC | PF_CTL_KNOB | PF_UNIT_COEF , NULL, "aging", "Aging" },
     { 1000,   600,   1800, 0,  PF_INT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_HZ , NULL, "freq", "Frequency" },
-    
+
     { 0.0078125, 0.000015849, 1, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "gain0", "Vol 0" },
     VINYL_SYNTH(0)
     { 0.0078125, 0.000015849, 1, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "gain1", "Vol 1" },
@@ -1593,7 +1593,7 @@ CALF_PORT_PROPS(vinyl) = {
     VINYL_SYNTH(5)
     { 0.0625, 0.000015849, 1, 0, PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "gain6", "Vol 6" },
     VINYL_SYNTH(6)
-    
+
     {}
 };
 
@@ -2140,7 +2140,7 @@ CALF_PORT_PROPS(widgets) = {
     { 0,    0,   1,    0,   PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_2", "Meter-2" },
     { 0,    0,   1,    0,   PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_3", "Meter-3" },
     { 0,    0,   1,    0,   PF_FLOAT | PF_SCALE_GAIN | PF_CTL_METER | PF_CTLO_LABEL | PF_UNIT_DB | PF_PROP_OUTPUT | PF_PROP_OPTIONAL, NULL, "meter_4", "Meter-4" },
-   
+
     { 0,    100, 100,  0.1, PF_FLOAT | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "value_lin", "Value Linear" },
     { 0,    100, 100,  0.1, PF_FLOAT | PF_SCALE_LOG | PF_CTL_KNOB | PF_UNIT_COEF, NULL, "value_log", "Value Logarithmic" },
     {}


### PR DESCRIPTION
The unit in this case is dBFS (absolute digital volume) not dB (analog/realtive volume).
Introduce a PF_UNIT_DBFS unit constant and use it in metadata.