### PR TITLE
crash fix: vector index

### DIFF
--- a/src/calf/jackhost.h
+++ b/src/calf/jackhost.h
@@ -146,8 +146,8 @@ public:
     
 public:
     // Port access
-    port *get_inputs() { return &inputs[0]; }
-    port *get_outputs() { return &outputs[0]; }
+    port *get_inputs() { return inputs.empty() ? NULL : &inputs[0]; }
+    port *get_outputs() { return outputs.empty() ? NULL : &outputs[0]; }
     float *get_params() { return param_values; }
     port *get_midi_port() { return get_metadata_iface()->get_midi() ? &midi_port : NULL; }
 public:

--- a/src/ctl_knob.cpp
+++ b/src/ctl_knob.cpp
@@ -216,7 +216,7 @@ calf_knob_expose (GtkWidget *widget, GdkEventExpose *event)
     }
     while (deg <= end) {
         if (self->debug) printf("tick %d deg %.2f last %.2f end %.2f\n", tick, deg, last, end);
-        if (self->ticks.size() and deg == start + range01(self->ticks[tick]) * base) {
+        if (self->ticks.size() and tick < self->ticks.size() and deg == start + range01(self->ticks[tick]) * base) {
             // seems we want to draw a tick on this angle.
             // so we have to fill the void between the last set angle
             // and the point directly before the tick first.


### PR DESCRIPTION
HI,
Recent hardening of build flags in Fedora uncovered a bug in calf that causes crash at two different places.

https://bugzilla.redhat.com/show_bug.cgi?id=1581433

We got user verification that the suggested commits fix the crash problem.