### PR TITLE
fix a segfault in limiter and a build error

### DIFF
--- a/src/audio_fx.cpp
+++ b/src/audio_fx.cpp
@@ -1361,7 +1361,7 @@ resampleN::~resampleN()
 }
 void resampleN::set_params(uint32_t sr, int fctr = 2, int fltrs = 2)
 {
-    srate   = std::max(2, sr);
+    srate   = std::max(2u, sr);
     factor  = std::min(16, std::max(1, fctr));
     filters = std::min(4, std::max(1, fltrs));
     // set all filters

--- a/src/modules_limit.cpp
+++ b/src/modules_limit.cpp
@@ -59,9 +59,11 @@ void limiter_audio_module::deactivate()
 }
 void limiter_audio_module::set_srates()
 {
-    resampler[0].set_params(srate, *params[param_oversampling], 2);
-    resampler[1].set_params(srate, *params[param_oversampling], 2);
-    limiter.set_sample_rate(srate * *params[param_oversampling]);
+    if (params[param_oversampling]) {
+        resampler[0].set_params(srate, *params[param_oversampling], 2);
+        resampler[1].set_params(srate, *params[param_oversampling], 2);
+        limiter.set_sample_rate(srate * *params[param_oversampling]);
+    }
 }
 void limiter_audio_module::params_changed()
 {


### PR DESCRIPTION
#188 
This fixes the crash in Limiter.
It considers that parameters may not be connected at the time of `set_sample_rate`.

If my understanding is correct, the null check is sufficient.
It will delay the update until later, in the chain of calls `activate` → `params_changed`.