### PR TITLE
Fix memory problems

### DIFF
--- a/src/calf/lv2wrap.h
+++ b/src/calf/lv2wrap.h
@@ -256,8 +256,8 @@ struct lv2_wrapper
     }
     
     static lv2_wrapper &get() { 
-        static lv2_wrapper *instance = new lv2_wrapper;
-        return *instance;
+        static lv2_wrapper instance;
+        return instance;
     }
 };
 

--- a/src/modules_filter.cpp
+++ b/src/modules_filter.cpp
@@ -52,6 +52,7 @@ equalizerNband_audio_module<BaseClass, has_lphp>::equalizerNband_audio_module()
     hp_freq_old = lp_freq_old = hp_q_old = 0;
     hs_freq_old = ls_freq_old = lp_q_old = 0;
     hs_level_old = ls_level_old = 0;
+    hs_q_old = ls_q_old = 0;
     keep_gliding = 0;
     last_peak = 0;
     indiv_old = -1;


### PR DESCRIPTION
Fixing a few problems I discover as I run calf plugins in valgrind and my [testing host](https://github.com/jpcima/lv2-plugin-checker).

* uninitialized members
* wrapper which is leaked when library unloads. I don't think it's a problem to have it stored in static segment instead.