### PR TITLE
Limiter: Allow toggling auto-leveling

### DIFF
--- a/doc/manuals/Limiter.html
+++ b/doc/manuals/Limiter.html
@@ -29,7 +29,8 @@
                 <li><strong>Split:</strong> Frequency to split between these strips</li>
                 <li><strong>S:</strong> Separate or overlap the frequencies of the neighbour bands</li>
                 <li><strong>Q:</strong> Raise the center frequency</li>
-                <li><strong>Limit:</strong> Don't let signals above this level pass the limiter. The removed amplitude is added automatically.</li>
+                <li><strong>Limit:</strong> Don't let signals above this level pass the limiter.</li>
+                <li><strong>Auto-level:</strong> If enabled, scales the output signal to 0 dBFS, effectively applying a gain equal to the inverse of the limit setting - adding back the removed amplitude in the process.</li>
                 <li><strong>Lookahead:</strong> The Limiter will reach its attenuation level in this amount of time (output will be delayed two times this time)</li>
                 <li><strong>Min Release:</strong>Don't let the release time fall beneath 2.5 times the lowest possible wavelength per band</li>
                 <li><strong>Release:</strong> Come back from limiting to attenuation 1.0 in this amount of milliseconds</li>

--- a/doc/manuals/Multiband Limiter.html
+++ b/doc/manuals/Multiband Limiter.html
@@ -34,7 +34,8 @@
                 <li><strong>Output (knob):</strong> Raise the overall volume after the compression stage</li>
                 <li><strong>Bypass:</strong> Don't process anything, just bypass the signal</li>
 
-                <li><strong>Limit:</strong> Don't let signals above this level pass the limiter. The removed amplitude is added automatically.</li>
+                <li><strong>Limit:</strong> Don't let signals above this level pass the limiter.</li>
+                <li><strong>Auto-level:</strong> If enabled, scales the output signal to 0 dBFS, effectively applying a gain equal to the inverse of the limit setting - adding back the removed amplitude in the process.</li>
                 <li><strong>Lookahead:</strong> The Limiter will reach its attenuation level in this amount of time (output will be delayed two times this time)</li>
                 <li><strong>Min Release:</strong>Don't let the release time fall beneath 2.5 times the lowest possible wavelength per band</li>
                 <li><strong>Release:</strong> Come back from limiting to attenuation 1.0 in this amount of milliseconds</li>

--- a/gui/gui/limiter.xml
+++ b/gui/gui/limiter.xml
@@ -34,6 +34,11 @@
         <hbox homogenous="1" spacing="25">
             <label/>
             <vbox>
+                 <label param="auto_level"/>
+                 <toggle param="auto_level" />
+                 <label />
+            </vbox>
+            <vbox>
                  <label param="oversampling"/>
                  <knob param="oversampling" size="3" ticks="1 2 3 4"/>
                  <value param="oversampling"/>

--- a/gui/gui/multibandlimiter.xml
+++ b/gui/gui/multibandlimiter.xml
@@ -42,6 +42,11 @@
     <frame label="Limit" expand="0" fill="1" attach-x="0" attach-y="0">
         <hbox spacing="2">
             <vbox>
+                 <label param="auto_level"/>
+                 <toggle param="auto_level" />
+                 <label />
+            </vbox>
+            <vbox>
                  <label param="oversampling"/>
                  <knob param="oversampling" size="3" ticks="1 2 3 4"/>
                  <value param="oversampling"/>

--- a/gui/gui/sidechainlimiter.xml
+++ b/gui/gui/sidechainlimiter.xml
@@ -53,6 +53,11 @@
     <frame label="Limit" expand="0" fill="1" attach-x="0" attach-y="0">
         <hbox spacing="2">
             <vbox>
+                 <label param="auto_level"/>
+                 <toggle param="auto_level" />
+                 <label />
+            </vbox>
+            <vbox>
                  <label param="oversampling"/>
                  <knob param="oversampling" size="3"/>
                  <value param="oversampling"/>

--- a/src/calf/metadata.h
+++ b/src/calf/metadata.h
@@ -355,6 +355,7 @@ struct limiter_metadata: public plugin_metadata<limiter_metadata>
            param_att,
            param_asc, param_asc_led, param_asc_coeff,
            param_oversampling,
+           param_auto_level,
            param_count };
     PLUGIN_NAME_ID_LABEL("limiter", "limiter", "Limiter")
 };
@@ -375,6 +376,7 @@ struct multibandlimiter_metadata: public plugin_metadata<multibandlimiter_metada
            param_effrelease0, param_effrelease1, param_effrelease2, param_effrelease3,
            param_asc, param_asc_led, param_asc_coeff,
            param_oversampling,
+           param_auto_level,
            param_count };
     PLUGIN_NAME_ID_LABEL("multibandlimiter", "multibandlimiter", "Multiband Limiter")
 };
@@ -396,6 +398,7 @@ struct sidechainlimiter_metadata: public plugin_metadata<sidechainlimiter_metada
            param_effrelease0, param_effrelease1, param_effrelease2, param_effrelease3, param_effrelease_sc,
            param_asc, param_asc_led, param_asc_coeff,
            param_oversampling, param_level_sc,
+           param_auto_level,
            param_count };
     PLUGIN_NAME_ID_LABEL("sidechainlimiter", "sidechainlimiter", "Sidechain Limiter")
 };

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -712,6 +712,7 @@ CALF_PORT_PROPS(limiter) = {
 
     { 0.5f,      0.f,         1.f,   0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "asc_coeff", "ASC Level" },
     { 1,           1,           4,   0,  PF_INT | PF_SCALE_LINEAR | PF_UNIT_COEF | PF_CTL_KNOB, NULL, "oversampling", "Oversampling" },
+    { 1,           0,           1,   0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "auto_level", "Auto-level" },
     {}
 };
 
@@ -767,6 +768,7 @@ CALF_PORT_PROPS(multibandlimiter) = {
     { 0.5f,      0.f,         1.f,   0,  PF_FLOAT | PF_SCALE_LINEAR | PF_CTL_KNOB | PF_UNIT_COEF | PF_PROP_GRAPH, NULL, "asc_coeff", "ASC Level" },
 
     { 1,           1,           4,   0,  PF_INT | PF_SCALE_LINEAR | PF_UNIT_COEF | PF_CTL_KNOB, NULL, "oversampling", "Oversampling" },
+    { 1,           0,           1,   0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "auto_level", "Auto-level" },
 
     {}
 };
@@ -831,6 +833,7 @@ CALF_PORT_PROPS(sidechainlimiter) = {
 
     { 1,           1,           4,   0,  PF_INT | PF_SCALE_LINEAR | PF_UNIT_COEF | PF_CTL_KNOB, NULL, "oversampling", "Oversampling" },
     { 1,           0.015625,    64,    0,  PF_FLOAT | PF_SCALE_GAIN | PF_CTL_KNOB | PF_UNIT_DB, NULL, "level_sc", "Level S/C"},
+    { 1,           0,           1,     0,  PF_BOOL | PF_CTL_TOGGLE, NULL, "auto_level", "Auto-level" },
     {}
 };
 

--- a/src/modules_limit.cpp
+++ b/src/modules_limit.cpp
@@ -151,8 +151,10 @@ uint32_t limiter_audio_module::process(uint32_t offset, uint32_t numsamples, uin
             outR = std::min(std::max(outR, -*params[param_limit]), *params[param_limit]);
 
             // autolevel
-            outL /= *params[param_limit];
-            outR /= *params[param_limit];
+            if (*params[param_auto_level]) {
+                outL /= *params[param_limit];
+                outR /= *params[param_limit];
+            }
 
             // out level
             outL *= *params[param_level_out];
@@ -484,8 +486,10 @@ uint32_t multibandlimiter_audio_module::process(uint32_t offset, uint32_t numsam
             }
             
             // autolevel
-            outL /= *params[param_limit];
-            outR /= *params[param_limit];
+            if (*params[param_auto_level]) {
+                outL /= *params[param_limit];
+                outR /= *params[param_limit];
+            }
 
             // out level
             outL *= *params[param_level_out];
@@ -867,8 +871,10 @@ uint32_t sidechainlimiter_audio_module::process(uint32_t offset, uint32_t numsam
             }
             
             // autolevel
-            outL /= *params[param_limit];
-            outR /= *params[param_limit];
+            if (*params[param_auto_level]) {
+                outL /= *params[param_limit];
+                outR /= *params[param_limit];
+            }
 
             // out level
             outL *= *params[param_level_out];


### PR DESCRIPTION
Sometimes the automatic scaling to 0 dBFS is not desired, for instance
if you want to use the limiter to simply impose a loudness cap on the signal
without changing the overall volume level.

It's currently possible to accomplish this by simply adjusting the
output gain knob to the inverse of the limiter knob, but this can be a
hassle when you want to make quick adjustments.

This patch introduces a new option to disable the auto-leveling
altogether, defaulting to on to avoid changing the current behavior.