### PR TITLE
Detect and builf properly for upcoming LV2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,7 @@ if test "$JACK_FOUND" = "yes"; then
   PKG_CHECK_MODULES(JACK_RENAME_PORT, jack >= 1.9.11, JACK_HAS_RENAME="yes", JACK_HAS_RENAME_DUMMY="no")
 fi
 
-PKG_CHECK_MODULES(LV2_DEPS, lv2core >= 6, LV2_FOUND="yes", LV2_FOUND="no")
+PKG_CHECK_MODULES(LV2_DEPS, lv2 >= 1.1.14, LV2_FOUND="yes", LV2_FOUND="no")
 
 PKG_CHECK_MODULES(LASH_DEPS, lash-1.0 >= 0.6.0,
   AC_CHECK_LIB([lash], [lash_client_is_being_restored], LASH_0_6_FOUND="yes", LASH_0_6_FOUND="no"),

--- a/src/calf/lv2_options.h
+++ b/src/calf/lv2_options.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #include "lv2_urid.h"
-#include "lv2.h"
+#include "lv2/lv2plug.in/ns/lv2core/lv2.h"
 
 #define LV2_OPTIONS_URI    "http://lv2plug.in/ns/ext/options"
 #define LV2_OPTIONS_PREFIX LV2_OPTIONS_URI "#"

--- a/src/calf/lv2_ui.h
+++ b/src/calf/lv2_ui.h
@@ -27,7 +27,7 @@
 
 #include <stdint.h>
 
-#include "lv2.h"
+#include "lv2/lv2plug.in/ns/lv2core/lv2.h"
 
 #define LV2_UI_URI "http://lv2plug.in/ns/extensions/ui"
 #define LV2_UI_PREFIX LV2_UI_URI "#"

--- a/src/calf/lv2wrap.h
+++ b/src/calf/lv2wrap.h
@@ -25,7 +25,7 @@
 
 #include <string>
 #include <vector>
-#include <lv2.h>
+#include "lv2/lv2plug.in/ns/lv2core/lv2.h"
 #include <calf/giface.h>
 #include <calf/lv2_atom.h>
 #include <calf/lv2_atom_util.h>

--- a/src/makerdf.cpp
+++ b/src/makerdf.cpp
@@ -22,7 +22,7 @@
 #include <calf/preset.h>
 #include <calf/utils.h>
 #if USE_LV2
-#include <lv2.h>
+#include "lv2/lv2plug.in/ns/lv2core/lv2.h"
 #include <calf/lv2_atom.h>
 #include <calf/lv2_options.h>
 #include <calf/lv2_state.h>


### PR DESCRIPTION
In [1] lv2-core.pc was removed and location of header files was reworked. This series prepares for next release of LV2.
Changes were build tested with LV2 1.14.0 and latest git

[1] https://github.com/drobilla/lv2/commit/4db67120efca2d4c200d2e1ba5cf3d7b97cab97e