### PR TITLE
fix headless mode (#184)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ doc/html/*
 dist/*
 .cproject
 .project
+compile

--- a/src/host_session.cpp
+++ b/src/host_session.cpp
@@ -48,10 +48,6 @@ host_session::host_session(session_environment_iface *se)
     save_file_on_next_idle_call = false;
     quit_on_next_idle_call = 0;
     handle_event_on_next_idle_call = NULL;
-    if (has_gui) {
-        main_win = session_env->create_main_window();
-        main_win->set_owner(this);
-    }
 }
 
 extern "C" plugin_metadata_iface *create_calf_metadata_by_name(const char *effect_name);
@@ -134,7 +130,10 @@ void host_session::open()
     
     client.open(client_name.c_str(), !jack_session_id.empty() ? jack_session_id.c_str() : NULL);
     jack_set_session_callback(client.client, session_callback, this);
+
     if (has_gui) {
+        main_win = session_env->create_main_window();
+        main_win->set_owner(this);
         main_win->add_condition("jackhost");
         main_win->add_condition("directlink");
         main_win->add_condition("configure");

--- a/src/jackhost.cpp
+++ b/src/jackhost.cpp
@@ -462,8 +462,6 @@ int main(int argc, char *argv[])
         sess.calfjackhost_cmd = path;
         free(path);
     }
-    if (sess.has_gui)
-        sess.session_env->init_gui(argc, argv);
     
     // Scan the options for the first time to find switches like --help, -h or -?
     // This avoids starting communication with LASH when displaying help text.
@@ -517,6 +515,7 @@ int main(int argc, char *argv[])
                 break;
             case 'n':
                 sess.has_gui = false;
+                sess.has_trayicon = false;
                 break;
             case 't':
                 sess.has_trayicon = false;
@@ -579,7 +578,12 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Error while loading presets: %s\n", e.what());
         exit(1);
     }
+
+        
     try {
+        if(sess.has_gui){
+            sess.session_env->init_gui(argc, argv);
+        }
         sess.open();
         sess.connect();
         sess.client.activate();


### PR DESCRIPTION
I moved the window creation out of the constructor of host_session and init_gui to a place where command line parameters are parsed, so that the default value of true is not used at this point.
(#184 )