### PR TITLE
fix event handlers when using no-gui (#184)

### DIFF
--- a/src/host_session.cpp
+++ b/src/host_session.cpp
@@ -157,9 +157,9 @@ void host_session::session_callback(jack_session_event_t *event, void *arg)
     case JackSessionSaveTemplate:
         host_session *hs = (host_session *)arg;
         if(hs->has_gui){
-            hs->handle_event_on_next_idle_call = event;
-        } else {
             hs->handle_jack_session_event(event);
+        } else {
+            hs->handle_event_on_next_idle_call = event;
         }
     }
     // XXXKF if more than one event happen in a short sequence, the other event

--- a/src/host_session.cpp
+++ b/src/host_session.cpp
@@ -156,7 +156,11 @@ void host_session::session_callback(jack_session_event_t *event, void *arg)
     case JackSessionSaveAndQuit:
     case JackSessionSaveTemplate:
         host_session *hs = (host_session *)arg;
-        hs->handle_event_on_next_idle_call = event;
+        if(hs->has_gui){
+            hs->handle_event_on_next_idle_call = event;
+        } else {
+            hs->handle_jack_session_event(event);
+        }
     }
     // XXXKF if more than one event happen in a short sequence, the other event
     // may be lost. This calls for implementing a proper event queue.
@@ -586,8 +590,7 @@ void host_session::on_idle()
     if (save_file_on_next_idle_call)
     {
         save_file_on_next_idle_call = false;
-        if (has_gui)
-            main_win->save_file();
+        main_win->save_file();
         printf("LADISH Level 1 support: file '%s' saved\n", get_current_filename().c_str());
     }
 

--- a/src/jackhost.cpp
+++ b/src/jackhost.cpp
@@ -590,11 +590,12 @@ int main(int argc, char *argv[])
         sess.set_signal_handlers();
         if (sess.has_gui) {
             sess.session_env->start_gui_loop();
-            sess.close();
         } else {
-            while (1)
+            while (sess.quit_on_next_idle_call == 0){
                 sleep(1);
+            }   
         }
+        sess.close();
     }
     catch(std::exception &e)
     {


### PR DESCRIPTION
`host_session` handles signals and sets up stopping gui_loop on next idle_call after which the main application terminates.
In --no-gui mode `host_session::on_idle()` is never called and the main application doesn't notice that a termination is requested.
So instead of a while(1)-loop,` quit_on_next_idle_call` is inquired to determine termination.
(#184)