### PR TITLE
fix segmentation fault [issue #232]

### DIFF
--- a/src/host_session.cpp
+++ b/src/host_session.cpp
@@ -367,8 +367,11 @@ void host_session::close()
 {
     if (session_manager)
         session_manager->disconnect();
-    if (has_gui)
+    if (has_gui){
         main_win->on_closed();
+        delete main_win;
+    }
+        
     client.deactivate();
     client.delete_plugins();
     client.destroy_automation_input();
@@ -644,7 +647,5 @@ void host_session::set_current_filename(const std::string &name)
 }
 
 host_session::~host_session()
-{
-    if (has_gui)
-        delete main_win;
+{      
 }


### PR DESCRIPTION
deallocation of main_win memory should not happen in host_session's deconstructor because its allocation happens in host_session::open() which may not be called (eg. on --version or --help flag).

This moves the deallocation to host_session::close() and should fix issue #232.

