### PR TITLE
FluidSynth minimum number of midi channels is 16

### DIFF
--- a/src/modules_dist.cpp
+++ b/src/modules_dist.cpp
@@ -832,7 +832,7 @@ void vinyl_audio_module::post_instantiate(uint32_t sr)
     settings = new_fluid_settings();
     fluid_settings_setnum(settings, "synth.sample-rate", sr);
     fluid_settings_setint(settings, "synth.polyphony", 32);
-    fluid_settings_setint(settings, "synth.midi-channels", _synths);
+    fluid_settings_setint(settings, "synth.midi-channels", std::max(16, _synths));
     fluid_settings_setint(settings, "synth.reverb.active", 0);
     fluid_settings_setint(settings, "synth.chorus.active", 0);
     


### PR DESCRIPTION
In response to the debug message `fluidsynth: error: requested set value for setting 'synth.midi-channels' out of range`. FluidSynth sets a minimum of 16 midi channels internally. In this case you set it to 7 (_synths) explicitly and get the minimum 16 back accompanied by a message. http://www.fluidsynth.org/api/fluidsettings.xml#synth.midi-channels
