### PR TITLE
calf_plugins::load_gui_xml: Fix catching exception by value

### DIFF
--- a/src/giface.cpp
+++ b/src/giface.cpp
@@ -324,7 +324,7 @@ char *calf_plugins::load_gui_xml(const std::string &plugin_id)
     try {
         return strdup(calf_utils::load_file((std::string(PKGLIBDIR) + "/" + plugin_id + ".xml").c_str()).c_str());
     }
-    catch(file_exception e)
+    catch(file_exception &e)
     {
         return NULL;
     }

--- a/src/giface.cpp
+++ b/src/giface.cpp
@@ -324,7 +324,7 @@ char *calf_plugins::load_gui_xml(const std::string &plugin_id)
     try {
         return strdup(calf_utils::load_file((std::string(PKGLIBDIR) + "/" + plugin_id + ".xml").c_str()).c_str());
     }
-    catch(file_exception &e)
+    catch(const file_exception &e)
     {
         return NULL;
     }


### PR DESCRIPTION
With `-Werror` with GCC 9:
```
error: catching polymorphic type 'struct calf_utils::file_exception' by value [-Werror=catch-value=]
```