### PR TITLE
Fix build with LLD

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,11 +39,7 @@ calfbenchmark_LDADD = libcalf.la
 
 libcalf_la_SOURCES = audio_fx.cpp analyzer.cpp lv2wrap.cpp metadata.cpp modules_tools.cpp modules_delay.cpp modules_comp.cpp modules_limit.cpp modules_dist.cpp modules_filter.cpp modules_mod.cpp modules_pitch.cpp fluidsynth.cpp giface.cpp monosynth.cpp organ.cpp osctl.cpp plugin.cpp preset.cpp synth.cpp utils.cpp wavetable.cpp modmatrix.cpp pffft.c shaping_clipper.cpp
 libcalf_la_LIBADD = $(FLUIDSYNTH_DEPS_LIBS) $(GLIB_DEPS_LIBS)
-if USE_DEBUG
 libcalf_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat -disable-static
-else
-libcalf_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat -disable-static -export-symbols-regex "lv2_descriptor"
-endif
 
 if USE_LV2_GUI
 


### PR DESCRIPTION
LLVM's LLD handles the -retain-symbols-file option (used by -export-symbols-regex in libtool) differently from GNU ld, causing undefined references during link. This commit removes the -export-symbols-regex option from libcalf_la_LDFLAGS since by default libtool exports all symbols anyway, so it should not be necessary.

Fixes https://github.com/calf-studio-gear/calf/issues/156.