### PR TITLE
Fixes #278: Do not read/write unconnected ports

### DIFF
--- a/src/modules_comp.cpp
+++ b/src/modules_comp.cpp
@@ -785,7 +785,8 @@ uint32_t compressor_audio_module::process(uint32_t offset, uint32_t numsamples, 
         // everything bypassed
         while(offset < numsamples) {
             outs[0][offset] = ins[0][offset];
-            outs[1][offset] = ins[1][offset];
+            if(outs[1])
+                outs[1][offset] = ins[ins[1]?1:0][offset];
             float values[] = {0, 0, 1};
             meters.process(values);
             ++offset;
@@ -802,9 +803,9 @@ uint32_t compressor_audio_module::process(uint32_t offset, uint32_t numsamples, 
             float outL = 0.f;
             float outR = 0.f;
             float inL = ins[0][offset];
-            float inR = ins[1][offset];
+            float inR = ins[ins[1]?1:0][offset];
             float Lin = ins[0][offset];
-            float Rin = ins[1][offset];
+            float Rin = ins[ins[1]?1:0][offset];
             
             // in level
             inR *= *params[param_level_in];
@@ -824,7 +825,8 @@ uint32_t compressor_audio_module::process(uint32_t offset, uint32_t numsamples, 
                 
             // send to output
             outs[0][offset] = outL;
-            outs[1][offset] = outR;
+            if(outs[1])
+                outs[1][offset] = outR;
 
             float values[] = {std::max(inL, inR), std::max(outL, outR), compressor.get_comp_level()};
             meters.process(values);
@@ -832,7 +834,7 @@ uint32_t compressor_audio_module::process(uint32_t offset, uint32_t numsamples, 
             // next sample
             ++offset;
         } // cycle trough samples
-        bypass.crossfade(ins, outs, 2, orig_offset, orig_numsamples);
+        bypass.crossfade(ins, outs, 1 + (int)(ins[1] && outs[1]), orig_offset, orig_numsamples);
     }
     meters.fall(numsamples);
     return outputs_mask;
@@ -2561,7 +2563,7 @@ uint32_t transientdesigner_audio_module::process(uint32_t offset, uint32_t numsa
     bool bypassed = bypass.update(*params[param_bypass] > 0.5f, numsamples);
     for(uint32_t i = offset; i < offset + numsamples; i++) {
         float L = ins[0][i];
-        float R = ins[1][i];
+        float R = ins[ins[1]?1:0][i];
         meter_inL   = 0.f;
         meter_inR   = 0.f;
         meter_outL  = 0.f;
@@ -2569,8 +2571,8 @@ uint32_t transientdesigner_audio_module::process(uint32_t offset, uint32_t numsa
         float s = (fabs(L) + fabs(R)) / 2;
         if(bypassed) {
             outs[0][i]  = ins[0][i];
-            outs[1][i]  = ins[1][i];
-            
+            if(outs[1])
+                outs[1][i]  = ins[ins[1]?1:0][i];
         } else {
             // levels in
             L *= *params[param_level_in];
@@ -2600,10 +2602,12 @@ uint32_t transientdesigner_audio_module::process(uint32_t offset, uint32_t numsa
             // output
             if (*params[param_listen] > 0.5) {
                 outs[0][i] = s;
-                outs[1][i] = s;
+                if(outs[1])
+                    outs[1][i] = s;
             } else {
                 outs[0][i] = L;
-                outs[1][i] = R;
+                if(outs[1])
+                    outs[1][i] = R;
             }
             meter_outL = L;
             meter_outR = R;
@@ -2677,7 +2681,7 @@ uint32_t transientdesigner_audio_module::process(uint32_t offset, uint32_t numsa
         meters.process(mval);
     }
     if (!bypassed)
-        bypass.crossfade(ins, outs, 2, orig_offset, numsamples);
+        bypass.crossfade(ins, outs, 1 + (int)(ins[1] && outs[1]), orig_offset, numsamples);
     meters.fall(numsamples);
     return outputs_mask;
 }

--- a/src/modules_delay.cpp
+++ b/src/modules_delay.cpp
@@ -432,7 +432,7 @@ void comp_delay_audio_module::set_sample_rate(uint32_t sr)
 uint32_t comp_delay_audio_module::process(uint32_t offset, uint32_t numsamples, uint32_t inputs_mask, uint32_t outputs_mask)
 {
     bool bypassed   = bypass.update(*params[param_bypass] > 0.5f, numsamples);
-    bool stereo     = ins[1];
+    bool stereo     = ins[1] && outs[1];
     uint32_t w_ptr  = write_ptr;
     uint32_t b_mask = buf_size - 2;
     uint32_t end    = offset + numsamples;
@@ -472,7 +472,7 @@ uint32_t comp_delay_audio_module::process(uint32_t offset, uint32_t numsamples, 
             w_ptr = (w_ptr + 2) & b_mask;
             r_ptr = (r_ptr + 2) & b_mask;
             
-            float values[] = {L, R, outs[0][i], outs[1][i]};
+            float values[] = {L, R, outs[0][i], outs[(int)stereo][i]};
             meters.process(values);
         }
     }


### PR DESCRIPTION
This should fix the following plugins in LMMS (and still work in other DAWs):

```
Compensation Delay Line
Saturator
Exciter
Bass Enhancer
Crusher
Stereo Tools
Multi Spread
Analyzer
Transient Designer
Tape Simulator
```

Note, I started LMMS like this:

```bash
LMMS_IGNORE_BLACKLIST=1 LV2_PATH=/path/to/calf/installation/of/this/pr/lib/lv2/ install/bin/lmms
```

What I did test:
* LMMS: Each effect does not crash when playing a note with default settings

What I did not test:
* Does it work in LMMS with non-default settings? Especially, changing options of the "Stereo Tools" might be interesting, because #278 is about issues with mono vs stereo.
* Does it still work in other DAWs?