### PR TITLE
Fix build with LLD

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,11 +50,7 @@ pkglib_LTLIBRARIES += libcalflv2gui.la
 
 libcalflv2gui_la_SOURCES = gui.cpp gui_config.cpp gui_controls.cpp ctl_curve.cpp ctl_keyboard.cpp ctl_knob.cpp ctl_led.cpp ctl_tube.cpp ctl_vumeter.cpp ctl_frame.cpp ctl_fader.cpp ctl_buttons.cpp ctl_notebook.cpp ctl_meterscale.cpp ctl_combobox.cpp ctl_tuner.cpp ctl_phasegraph.cpp ctl_pattern.cpp metadata.cpp giface.cpp plugin_gui_window.cpp preset.cpp preset_gui.cpp lv2gui.cpp osctl.cpp utils.cpp ctl_linegraph.cpp drawingutils.cpp
 
-if USE_DEBUG
 libcalflv2gui_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat $(GUI_DEPS_LIBS) -disable-static
-else
-libcalflv2gui_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat -export-symbols-regex "lv2ui_descriptor" $(GUI_DEPS_LIBS) -disable-static
-endif
 
 if HAVE_LD_NODELETE
 libcalflv2gui_la_LDFLAGS += -Wl,-z,nodelete


### PR DESCRIPTION
LLVM's LLD handles the -retain-symbols-file option (used by
-export-symbols-regex in libtool) differently from GNU ld, causing
undefined references during link. This commit removes the
-export-symbols-regex option from libcalf_la_LDFLAGS since by default
libtool exports all symbols anyway, so it should not be necessary.

Follow-up of f6c6aaef3d8c744faefa13842fd452323bb30750 .