### PR TITLE
Automake: Remove use of the -module parameter

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,7 +39,7 @@ calfbenchmark_LDADD = libcalf.la
 
 libcalf_la_SOURCES = audio_fx.cpp analyzer.cpp lv2wrap.cpp metadata.cpp modules_tools.cpp modules_delay.cpp modules_comp.cpp modules_limit.cpp modules_dist.cpp modules_filter.cpp modules_mod.cpp modules_pitch.cpp fluidsynth.cpp giface.cpp monosynth.cpp organ.cpp osctl.cpp plugin.cpp preset.cpp synth.cpp utils.cpp wavetable.cpp modmatrix.cpp pffft.c shaping_clipper.cpp
 libcalf_la_LIBADD = $(FLUIDSYNTH_DEPS_LIBS) $(GLIB_DEPS_LIBS)
-libcalf_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat -disable-static
+libcalf_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -lexpat -disable-static
 
 if USE_LV2_GUI
 
@@ -50,7 +50,7 @@ pkglib_LTLIBRARIES += libcalflv2gui.la
 
 libcalflv2gui_la_SOURCES = gui.cpp gui_config.cpp gui_controls.cpp ctl_curve.cpp ctl_keyboard.cpp ctl_knob.cpp ctl_led.cpp ctl_tube.cpp ctl_vumeter.cpp ctl_frame.cpp ctl_fader.cpp ctl_buttons.cpp ctl_notebook.cpp ctl_meterscale.cpp ctl_combobox.cpp ctl_tuner.cpp ctl_phasegraph.cpp ctl_pattern.cpp metadata.cpp giface.cpp plugin_gui_window.cpp preset.cpp preset_gui.cpp lv2gui.cpp osctl.cpp utils.cpp ctl_linegraph.cpp drawingutils.cpp
 
-libcalflv2gui_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat $(GUI_DEPS_LIBS) -disable-static
+libcalflv2gui_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -lexpat $(GUI_DEPS_LIBS) -disable-static
 
 if HAVE_LD_NODELETE
 libcalflv2gui_la_LDFLAGS += -Wl,-z,nodelete


### PR DESCRIPTION
Feel free to review, but I will merge this in the next 24 hours.

Source: https://cgit.freebsd.org/ports/tree/audio/calf-lv2/files/patch-src_Makefile.am

References #306 