### PR TITLE
Fix FluidSynth detection on Windows when using vcpkg

### DIFF
--- a/cmake/FindFluidSynth.cmake
+++ b/cmake/FindFluidSynth.cmake
@@ -22,7 +22,7 @@ find_path(FluidSynth_INCLUDE_DIRS
 )
 
 find_library(FluidSynth_LIBRARY
-	NAMES "fluidsynth"
+	NAMES "fluidsynth" "fluidsynth-3" "fluidsynth-2" "fluidsynth-1"
 	HINTS ${FLUIDSYNTH_PKG_LIBRARY_DIRS}
 )
 


### PR DESCRIPTION
This PR should fix the broken MSVC CI.

It was broken because on Windows, the FluidSynth library is named "fluidsynth-3" rather than just "fluidsynth". I think this is because the Linux version uses ".so.3" so they did it that way as the Windows equivalent.

NOTE: Since you cache the vcpkg builds, this problem might not be visible until you delete the cache or otherwise are forced to rebuild the vcpkg packages. I fixed this exact same problem in LMMS/lmms. See: https://github.com/LMMS/lmms/pull/7702
