### PR TITLE
Fix calf.desktop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ missing
 calf-*.tar.gz
 aclocal.m4
 stamp-h1
-calf.desktop
 autom4te.cache
 bigbull/build
 bigbull/ttl.cpp

--- a/.svnignore
+++ b/.svnignore
@@ -11,5 +11,4 @@ aclocal.m4
 Makefile.in
 config.status
 ltmain.sh
-calf.desktop
 Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,6 @@ else()
 endif()
 
 configure_file(config.h.cmake.in config.h)
-configure_file(${PROJECT_NAME}.desktop.in ${PROJECT_NAME}.desktop)
 include_directories(${CMAKE_BINARY_DIR})
 
 #
@@ -231,7 +230,7 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/doc/manuals/scripts/
         DESTINATION ${CMAKE_INSTALL_DOCDIR}/scripts FILES_MATCHING PATTERN "*.js")
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/sf2/
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/sf2 FILES_MATCHING PATTERN "*.sf2")
-install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.desktop
+install(FILES ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}.desktop
         DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
 install(FILES ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}jackhost.1
         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)

--- a/calf.desktop
+++ b/calf.desktop
@@ -1,10 +1,11 @@
 [Desktop Entry]
-Categories=Application;AudioVideo;Audio;GNOME
+Type=Application
+Version=1.5
+
+Categories=AudioVideo;Audio;Sequencer;X-Jack;GTK
 Exec=calfjackhost
 Icon=calf
 Terminal=false
-Type=Application
-Version=@VERSION@
 
 Name=Calf Plugin Pack for JACK
 Name[fr]=Ensemble de greffons Calf pour JACK

--- a/configure.ac.deprecated
+++ b/configure.ac.deprecated
@@ -279,7 +279,6 @@ AM_CONDITIONAL([ENABLE_BASH_COMPLETION],[test "x$with_bash_completion_dir" != "x
 ############################################################################################
 # Output files for configure step
 AC_CONFIG_FILES([Makefile
-                 calf.desktop
                  gui/Makefile
                  gui/icons/LV2/Makefile
                  icons/Makefile


### PR DESCRIPTION
The `Version` must be the "Version of the Desktop Entry Specification", and not of the application.

This also updates/fixes the `Categories` section.

Fixes https://955628.bugs.gentoo.org/attachment.cgi?id=928147 .